### PR TITLE
Feat send and validate email

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
@@ -42,6 +44,9 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/naribackend/api/auth/v1/AuthController.java
+++ b/src/main/java/com/naribackend/api/auth/v1/AuthController.java
@@ -1,0 +1,33 @@
+package com.naribackend.api.auth.v1;
+
+import com.naribackend.api.auth.v1.request.SendVerificationCodeRequest;
+import com.naribackend.core.auth.AuthService;
+import com.naribackend.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+
+    @Operation(
+            summary = "이메일 인증 코드 발송",
+            description = "이메일 인증 코드를 발송 합니다."
+    )
+    @PostMapping("/email-verification-code")
+    public ResponseEntity<ApiResponse<?>> sendVerificationCode(
+         @RequestBody @Valid final SendVerificationCodeRequest request
+    ) {
+        authService.processVerificationCode(request.toUserEmail());
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+}

--- a/src/main/java/com/naribackend/api/auth/v1/request/SendVerificationCodeRequest.java
+++ b/src/main/java/com/naribackend/api/auth/v1/request/SendVerificationCodeRequest.java
@@ -1,0 +1,17 @@
+package com.naribackend.api.auth.v1.request;
+
+import com.naribackend.core.email.UserEmail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SendVerificationCodeRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        @Schema(description = "인증 코드를 받을 이메일 주소", example = "user@example.com")
+        String toEmail
+){
+        public UserEmail toUserEmail() {
+                return UserEmail.from(toEmail);
+        }
+}

--- a/src/main/java/com/naribackend/config/AsyncConfig.java
+++ b/src/main/java/com/naribackend/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package com.naribackend.config;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@EnableRetry
+@Configuration
+public class AsyncConfig  implements AsyncConfigurer {
+
+    @Bean(name = "emailTaskExecutor")
+    public ThreadPoolTaskExecutor emailTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("EmailExec-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                LoggerFactory.getLogger(method.getDeclaringClass())
+                        .error("Async 예외 in {} with params {}", method.getName(), params, ex);
+    }
+}

--- a/src/main/java/com/naribackend/config/AsyncConfig.java
+++ b/src/main/java/com/naribackend/config/AsyncConfig.java
@@ -19,7 +19,7 @@ public class AsyncConfig  implements AsyncConfigurer {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5);
         executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(50);
+        executor.setQueueCapacity(1000);
         executor.setThreadNamePrefix("EmailExec-");
         executor.initialize();
         return executor;

--- a/src/main/java/com/naribackend/config/OpenApiConfig.java
+++ b/src/main/java/com/naribackend/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.naribackend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new io.swagger.v3.oas.models.info.Info()
+                        .title("NARI API")
+                        .version("1.0.0")
+                        .description("API documentation for Nari application"));
+    }
+}

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.naribackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/v1/auth/email-verification-code").permitAll()
+                    .requestMatchers(
+                            "/v3/api-docs/**",
+                            "/swagger-ui.html",
+                            "/swagger-ui/**"
+                    ).permitAll()
+                    .anyRequest().authenticated()
+            );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -1,0 +1,34 @@
+package com.naribackend.core.auth;
+
+import com.naribackend.core.email.UserEmail;
+import com.naribackend.core.email.EmailSender;
+import com.naribackend.core.email.EmailMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final EmailSender emailSender;
+
+    private final EmailVerificationModifier emailVerificationModifier;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final EmailVerificationAppender emailVerificationAppender;
+
+    public void processVerificationCode(final UserEmail toUserEmail) {
+        final VerificationCode verificationCode = VerificationCode.generateSixDigitCode();
+        final EmailMessage emailMessage = EmailMessage.getVerificationCodeEmailMessage(
+                toUserEmail,
+                verificationCode
+        );
+
+        emailSender.sendEmail(emailMessage);
+
+        if(!emailVerificationRepository.existsByUserEmail(toUserEmail)) {
+            emailVerificationAppender.appendEmailVerification(toUserEmail, verificationCode);
+        } else {
+            emailVerificationModifier.modifyVerificationCodeByUserEmail(toUserEmail, verificationCode);
+        }
+    }
+}

--- a/src/main/java/com/naribackend/core/auth/EmailVerification.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerification.java
@@ -1,0 +1,44 @@
+package com.naribackend.core.auth;
+
+import com.naribackend.core.email.UserEmail;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class EmailVerification {
+
+    private final Long id;
+    private final UserEmail userEmail;
+    private VerificationCode verificationCode;
+    private final boolean isVerified;
+
+    @Builder
+    public EmailVerification(
+        final Long id,
+        final UserEmail userEmail,
+        final VerificationCode verificationCode,
+        final boolean isVerified
+    ) {
+        this.id = id;
+        this.userEmail = userEmail;
+        this.verificationCode = verificationCode;
+        this.isVerified = isVerified;
+    }
+
+    public void updateVerificationCode(final VerificationCode newVerificationCode) {
+        this.verificationCode = newVerificationCode;
+    }
+
+    public String getUserEmailStr() {
+        return userEmail.getAddress();
+    }
+
+    public String verificationCodeStr() {
+        return verificationCode.toString();
+    }
+}

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationAppender.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationAppender.java
@@ -1,0 +1,22 @@
+package com.naribackend.core.auth;
+
+import com.naribackend.core.email.UserEmail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationAppender {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    public void appendEmailVerification(final UserEmail toUserEmail, final VerificationCode verificationCode) {
+        EmailVerification emailVerification = EmailVerification.builder()
+                .userEmail(toUserEmail)
+                .verificationCode(verificationCode)
+                .isVerified(false)
+                .build();
+
+        emailVerificationRepository.appendEmailVerification(emailVerification);
+    }
+}

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationModifier.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationModifier.java
@@ -1,0 +1,23 @@
+package com.naribackend.core.auth;
+
+import com.naribackend.core.email.UserEmail;
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationModifier {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    public void modifyVerificationCodeByUserEmail(final UserEmail targetUserEmail, final VerificationCode newVerificationCode) {
+        EmailVerification foundEmailVerification = emailVerificationRepository.findByUserEmail(targetUserEmail)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_EMAIL));
+
+        foundEmailVerification.updateVerificationCode(newVerificationCode);
+
+        emailVerificationRepository.modifyEmailVerification(foundEmailVerification);
+    }
+}

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationRepository.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationRepository.java
@@ -1,0 +1,16 @@
+package com.naribackend.core.auth;
+
+import com.naribackend.core.email.UserEmail;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository {
+
+    void appendEmailVerification(EmailVerification emailVerification);
+
+    Optional<EmailVerification> findByUserEmail(UserEmail userEmail);
+
+    boolean existsByUserEmail(UserEmail userEmail);
+
+    void modifyEmailVerification(EmailVerification emailVerification);
+}

--- a/src/main/java/com/naribackend/core/auth/VerificationCode.java
+++ b/src/main/java/com/naribackend/core/auth/VerificationCode.java
@@ -1,0 +1,32 @@
+package com.naribackend.core.auth;
+
+import lombok.RequiredArgsConstructor;
+
+import java.security.SecureRandom;
+
+@RequiredArgsConstructor
+public class VerificationCode {
+
+    private static final SecureRandom SR = new SecureRandom();
+
+    private final String code;
+
+    /**
+     * 6자리 정수로 이루어진 인증코드 생성
+     * @return 6자리 정수로 이루어진 인증코드를 가진 VerificationCode 객체 반환
+     */
+    public static VerificationCode generateSixDigitCode() {
+        String code = String.format("%06d", SR.nextInt(1_000_000));
+
+        return new VerificationCode(code);
+    }
+
+    public static VerificationCode from(final String code) {
+        return new VerificationCode(code);
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/src/main/java/com/naribackend/core/email/EmailMessage.java
+++ b/src/main/java/com/naribackend/core/email/EmailMessage.java
@@ -1,0 +1,30 @@
+package com.naribackend.core.email;
+
+import com.naribackend.core.auth.VerificationCode;
+import lombok.Builder;
+
+@Builder
+public record EmailMessage(
+        UserEmail toUserEmail,
+        String subject,
+        String content
+) {
+
+    private static final String DEFAULT_SUBJECT = "NARI 인증코드 발송";
+    private static final String DEFAULT_CONTENT = "인증코드: ";
+
+    public String getToEmailAddress() {
+        return toUserEmail.getAddress();
+    }
+
+    public static EmailMessage getVerificationCodeEmailMessage(
+            final UserEmail toUserEmail,
+            final VerificationCode verificationCode
+    ) {
+        return EmailMessage.builder()
+                .toUserEmail(toUserEmail)
+                .subject(DEFAULT_SUBJECT)
+                .content(DEFAULT_CONTENT + verificationCode)
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/core/email/EmailSender.java
+++ b/src/main/java/com/naribackend/core/email/EmailSender.java
@@ -1,0 +1,6 @@
+package com.naribackend.core.email;
+
+public interface EmailSender {
+
+    void sendEmail(EmailMessage emailMessage);
+}

--- a/src/main/java/com/naribackend/core/email/UserEmail.java
+++ b/src/main/java/com/naribackend/core/email/UserEmail.java
@@ -1,0 +1,34 @@
+package com.naribackend.core.email;
+
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
+import lombok.Getter;
+
+import java.util.regex.Pattern;
+
+@Getter
+public class UserEmail {
+
+    private final String address;
+
+    // RFC 5322 공식 REGEX
+    private static final String REGEX = "^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$";
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile(REGEX, Pattern.CASE_INSENSITIVE);
+
+    public UserEmail(final String address) {
+        if (address == null || !isValid(address)) {
+            throw new CoreException(ErrorType.INVALID_EMAIL);
+        }
+
+        this.address = address;
+    }
+
+    public static UserEmail from(final String email) {
+        return new UserEmail(email);
+    }
+
+    private boolean isValid(final String email) {
+        return EMAIL_PATTERN.matcher(email).matches();
+    }
+}

--- a/src/main/java/com/naribackend/infra/mail/SmtpEmailSender.java
+++ b/src/main/java/com/naribackend/infra/mail/SmtpEmailSender.java
@@ -2,17 +2,32 @@ package com.naribackend.infra.mail;
 
 import com.naribackend.core.email.EmailSender;
 import com.naribackend.core.email.EmailMessage;
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender javaMailSender;
 
+    @Async("emailTaskExecutor")
+    @Retryable(
+            retryFor = { CoreException.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     @Override
     public void sendEmail(EmailMessage emailMessage) {
         SimpleMailMessage msg = new SimpleMailMessage();
@@ -21,6 +36,19 @@ public class SmtpEmailSender implements EmailSender {
         msg.setSubject(emailMessage.subject());
         msg.setText(emailMessage.content());
 
-        javaMailSender.send(msg);
+        try {
+            javaMailSender.send(msg);
+        } catch (MailException e) {
+            throw new CoreException(ErrorType.SEND_EMAIL_FAILED, e);
+        }
+
+    }
+
+    /**
+     * 이 메서드는 @Retryable이 실패한 후에 호출됩니다.
+     */
+    @Recover
+    public void recover(CoreException ex, EmailMessage emailMessage) {
+        log.error("All retry attempts failed for {}: {}", emailMessage.getToEmailAddress(), ex.toString());
     }
 }

--- a/src/main/java/com/naribackend/infra/mail/SmtpEmailSender.java
+++ b/src/main/java/com/naribackend/infra/mail/SmtpEmailSender.java
@@ -1,0 +1,26 @@
+package com.naribackend.infra.mail;
+
+import com.naribackend.core.email.EmailSender;
+import com.naribackend.core.email.EmailMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void sendEmail(EmailMessage emailMessage) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+
+        msg.setTo(emailMessage.getToEmailAddress());
+        msg.setSubject(emailMessage.subject());
+        msg.setText(emailMessage.content());
+
+        javaMailSender.send(msg);
+    }
+}

--- a/src/main/java/com/naribackend/storage/BaseEntity.java
+++ b/src/main/java/com/naribackend/storage/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.naribackend.storage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationEntity.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationEntity.java
@@ -1,0 +1,51 @@
+package com.naribackend.storage.auth;
+
+import com.naribackend.core.auth.EmailVerification;
+import com.naribackend.core.auth.VerificationCode;
+import com.naribackend.core.email.UserEmail;
+import com.naribackend.storage.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@Table(name = "email_verification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerificationEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_email", nullable = false)
+    private String userEmail;
+
+    @Column(name = "verification_code", nullable = false)
+    private String verificationCode;
+
+    @Column(name = "is_verified", nullable = false)
+    private boolean isVerified;
+
+
+    public static EmailVerificationEntity from(final EmailVerification emailVerification) {
+        return EmailVerificationEntity.builder()
+                .id(emailVerification.getId())
+                .userEmail(emailVerification.getUserEmailStr())
+                .verificationCode(emailVerification.verificationCodeStr())
+                .isVerified(emailVerification.isVerified())
+                .build();
+    }
+
+    public EmailVerification toEmailVerification() {
+        return EmailVerification.builder()
+                .id(id)
+                .userEmail(UserEmail.from(userEmail))
+                .verificationCode(VerificationCode.from(verificationCode))
+                .isVerified(isVerified)
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationEntityRepository.java
@@ -1,0 +1,42 @@
+package com.naribackend.storage.auth;
+
+import com.naribackend.core.auth.EmailVerification;
+import com.naribackend.core.auth.EmailVerificationRepository;
+import com.naribackend.core.email.UserEmail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationEntityRepository implements EmailVerificationRepository {
+
+    private final EmailVerificationJpaRepository emailVerificationJpaRepository;
+
+    @Override
+    public void appendEmailVerification(final EmailVerification emailVerification) {
+        EmailVerificationEntity emailVerificationEntity = EmailVerificationEntity.from(emailVerification);
+
+        emailVerificationJpaRepository.save(emailVerificationEntity);
+    }
+
+    @Override
+    public Optional<EmailVerification> findByUserEmail(UserEmail userEmail) {
+        String userEmailStr = userEmail.getAddress();
+
+        return emailVerificationJpaRepository.findByUserEmail(userEmailStr).map(EmailVerificationEntity::toEmailVerification);
+    }
+
+    @Override
+    public boolean existsByUserEmail(UserEmail userEmail) {
+        return emailVerificationJpaRepository.existsByUserEmail(userEmail.getAddress());
+    }
+
+    @Override
+    public void modifyEmailVerification(EmailVerification emailVerification) {
+        EmailVerificationEntity emailVerificationEntity = EmailVerificationEntity.from(emailVerification);
+
+        emailVerificationJpaRepository.save(emailVerificationEntity);
+    }
+}

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationJpaRepository.java
@@ -1,0 +1,12 @@
+package com.naribackend.storage.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationJpaRepository extends JpaRepository<EmailVerificationEntity, Long> {
+
+    Optional<EmailVerificationEntity> findByUserEmail(String userEmail);
+
+    boolean existsByUserEmail(String userEmail);
+}

--- a/src/main/java/com/naribackend/support/error/CoreException.java
+++ b/src/main/java/com/naribackend/support/error/CoreException.java
@@ -21,4 +21,15 @@ public class CoreException extends RuntimeException {
         this.data = data;
     }
 
+    public CoreException(final ErrorType errorType, final Throwable cause) {
+        super(errorType.getMessage(), cause);
+        this.errorType = errorType;
+        this.data = null;
+    }
+
+    public CoreException(final ErrorType errorType, final Object data, final Throwable cause) {
+        super(errorType.getMessage(), cause);
+        this.errorType = errorType;
+        this.data = data;
+    }
 }

--- a/src/main/java/com/naribackend/support/error/CoreException.java
+++ b/src/main/java/com/naribackend/support/error/CoreException.java
@@ -9,13 +9,13 @@ public class CoreException extends RuntimeException {
 
     private final Object data;
 
-    public CoreException(ErrorType errorType) {
+    public CoreException(final ErrorType errorType) {
         super(errorType.getMessage());
         this.errorType = errorType;
         this.data = null;
     }
 
-    public CoreException(ErrorType errorType, Object data) {
+    public CoreException(final ErrorType errorType, final Object data) {
         super(errorType.getMessage());
         this.errorType = errorType;
         this.data = data;

--- a/src/main/java/com/naribackend/support/error/ErrorCode.java
+++ b/src/main/java/com/naribackend/support/error/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.naribackend.support.error;
 
 public enum ErrorCode {
+    E400,
     E500
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorType {
 
-    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
-            LogLevel.ERROR);
+    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 이메일 형식입니다.", LogLevel.INFO),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 입력 값입니다.", LogLevel.INFO),
+    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, ErrorCode.E400, "이메일을 찾을 수 없습니다.", LogLevel.INFO)
+    ;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
+    SEND_EMAIL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "이메일 전송에 실패했습니다.", LogLevel.ERROR),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 이메일 형식입니다.", LogLevel.INFO),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 입력 값입니다.", LogLevel.INFO),
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, ErrorCode.E400, "이메일을 찾을 수 없습니다.", LogLevel.INFO)


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

### 메일 전송 및 저장 기능 추가
- 사용자가 이메일을 입력하면, 해당 이메일로 인증 번호를 전송합니다.
- 인증 번호는 이메일과 함께 DB에 저장 됩니다.
- 이메일 전송을 동기로 만들었을 때, 2~3초이상 걸려서 이메일 전송 부분만 async로 작성하였습니다.
<br>

## 📌 주의해야할 점이 있나요?

### 이메일 전송 async 
- 이메일 전송 async는 대기큐의 최대 크기는 1000 입니다.
- 메일 인증 요청이 1000개가 넘는 경우 메일 전송이 실패하니 이 점 주의해야 합니다.
- 현재, 동시에 1000명이 넘는 사용자가 인증 요청을 보내지 않을거라고 가정하고 만들었습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->