### PR TITLE
[feat] CORS 설정 및 프록시 환경 대응을 위한 ForwardedHeaderFilter 추가

### DIFF
--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -5,6 +5,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -12,6 +17,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
         http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/v1/auth/email-verification-code").permitAll()
@@ -24,5 +30,23 @@ public class SecurityConfig {
             );
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(
+                List.of(
+                        "https://nari-web.com", "https://api.nari-web.com", "https://www.nari-web.com",
+                        "http://localhost:3000"
+                )
+        );
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/naribackend/config/WebConfig.java
+++ b/src/main/java/com/naribackend/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.naribackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+@Configuration
+public class WebConfig {
+
+    /**
+     * ForwardedHeaderFilter is used to handle the X-Forwarded-* headers
+     * that are added by proxies (like Nginx) to support SSL termination.
+     * This filter will ensure that the original request scheme and host
+     * are preserved when the application is behind a proxy.
+     */
+    @Bean
+    public ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
+    }
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

### [현재 도메인과 개발 환경에 맞게 cors 설정](https://github.com/Nari-Natural-AI-for-Reflecting-Insight/NARI-Backend/commit/85edd51f44e1fe8e0fc7438e77365f4ad19b94b2)
- 현재 배포 도메인 (https://www.nari-web.com) 및 개발 환경(http://localhost:3000)에 맞춰 CORS 설정을 적용했습니다.

### [프록시 환경 대응을 위한 ForwardedHeaderFilter 설정 추가](https://github.com/Nari-Natural-AI-for-Reflecting-Insight/NARI-Backend/commit/39b0e0bf378c527836b09e50657cf53dd28de545)
- Nginx 같은 프록시 환경에서 요청의 원래 정보를 정확하게 인식할 수 있도록 ForwardedHeaderFilter를 설정에 추가했습니다.
- 이를 통해 HTTPS 사용 시 request.getScheme() 값이 정확히 유지됩니다. (스웨거에서 api 테스트할때 사용) 

<br>

## 📌 주의해야할 점이 있나요?
### CORS 설정 범위 & 프록시 서버 설정 
- CORS 허용 도메인을 운영 환경에 맞게 관리해야 하며, 불필요하게 허용 범위를 넓히지 않도록 주의가 필요합니다.
- 프록시 서버가 X-Forwarded-* 헤더를 정상적으로 설정하고 있어야 ForwardedHeaderFilter가 정확히 동작합니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->