### PR TITLE
[feat, refactor] 이메일 인증 번호 검증 기능 추가 (close #3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
     implementation 'org.springframework.retry:spring-retry'
 }
 

--- a/src/main/java/com/naribackend/api/auth/v1/AuthController.java
+++ b/src/main/java/com/naribackend/api/auth/v1/AuthController.java
@@ -1,5 +1,6 @@
 package com.naribackend.api.auth.v1;
 
+import com.naribackend.api.auth.v1.request.CheckVerificationCodeRequest;
 import com.naribackend.api.auth.v1.request.SendVerificationCodeRequest;
 import com.naribackend.core.auth.AuthService;
 import com.naribackend.support.response.ApiResponse;
@@ -25,6 +26,19 @@ public class AuthController {
          @RequestBody @Valid final SendVerificationCodeRequest request
     ) {
         authService.processVerificationCode(request.toUserEmail());
+
+        return ApiResponse.success();
+    }
+
+    @Operation(
+            summary = "이메일 인증 코드 확인",
+            description = "이메일 인증 코드를 확인합니다."
+    )
+    @PostMapping("/email-verification-code/check")
+    public ApiResponse<?> checkVerificationCode(
+            @RequestBody @Valid final CheckVerificationCodeRequest request
+    ) {
+        authService.checkVerificationCode(request.toUserEmail(), request.toVerificationCode());
 
         return ApiResponse.success();
     }

--- a/src/main/java/com/naribackend/api/auth/v1/request/CheckVerificationCodeRequest.java
+++ b/src/main/java/com/naribackend/api/auth/v1/request/CheckVerificationCodeRequest.java
@@ -1,0 +1,25 @@
+package com.naribackend.api.auth.v1.request;
+
+import com.naribackend.core.auth.VerificationCode;
+import com.naribackend.core.email.UserEmail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckVerificationCodeRequest (
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        @Schema(description = "인증 코드를 받을 이메일 주소", example = "user@example.com")
+        String targetEmail,
+
+        @NotBlank(message = "인증 코드는 필수입니다.")
+        String verificationCode
+){
+    public UserEmail toUserEmail() {
+        return UserEmail.from(targetEmail);
+    }
+
+    public VerificationCode toVerificationCode() {
+        return VerificationCode.from(verificationCode);
+    }
+}

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -20,7 +20,10 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/v1/auth/email-verification-code").permitAll()
+                    .requestMatchers(
+                            "/api/v1/auth/email-verification-code",
+                            "/api/v1/auth/email-verification-code/check"
+                    ).permitAll()
                     .requestMatchers(
                             "/v3/api-docs/**",
                             "/swagger-ui.html",

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -3,6 +3,8 @@ package com.naribackend.core.auth;
 import com.naribackend.core.email.UserEmail;
 import com.naribackend.core.email.EmailSender;
 import com.naribackend.core.email.EmailMessage;
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,5 +32,21 @@ public class AuthService {
         } else {
             emailVerificationModifier.modifyVerificationCodeByUserEmail(toUserEmail, verificationCode);
         }
+    }
+
+    public void checkVerificationCode(
+            final UserEmail targetEmail,
+            final VerificationCode verificationCode
+    ) {
+        final EmailVerification savedEmailVerification = emailVerificationRepository.findByUserEmail(targetEmail)
+                .orElseThrow(
+                        () -> new CoreException(ErrorType.NOT_FOUND_EMAIL)
+                );
+
+        if (!savedEmailVerification.isSameVerificationCode(verificationCode)) {
+            throw new CoreException(ErrorType.INVALID_VERIFICATION_CODE);
+        }
+
+        emailVerificationModifier.modifyAsVerified(savedEmailVerification);
     }
 }

--- a/src/main/java/com/naribackend/core/auth/EmailVerification.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerification.java
@@ -15,7 +15,7 @@ public class EmailVerification {
     private final Long id;
     private final UserEmail userEmail;
     private VerificationCode verificationCode;
-    private final boolean isVerified;
+    private boolean isVerified;
 
     @Builder
     public EmailVerification(
@@ -40,5 +40,13 @@ public class EmailVerification {
 
     public String verificationCodeStr() {
         return verificationCode.toString();
+    }
+
+    public boolean isSameVerificationCode(final VerificationCode verificationCode) {
+        return this.verificationCode.equals(verificationCode);
+    }
+
+    public void markAsVerified() {
+        this.isVerified = true;
     }
 }

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationAppender.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationAppender.java
@@ -17,6 +17,6 @@ public class EmailVerificationAppender {
                 .isVerified(false)
                 .build();
 
-        emailVerificationRepository.appendEmailVerification(emailVerification);
+        emailVerificationRepository.saveEmailVerification(emailVerification);
     }
 }

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationModifier.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationModifier.java
@@ -18,6 +18,12 @@ public class EmailVerificationModifier {
 
         foundEmailVerification.updateVerificationCode(newVerificationCode);
 
-        emailVerificationRepository.modifyEmailVerification(foundEmailVerification);
+        emailVerificationRepository.saveEmailVerification(foundEmailVerification);
+    }
+
+    public void modifyAsVerified(final EmailVerification savedEmailVerification) {
+        savedEmailVerification.markAsVerified();
+
+        emailVerificationRepository.saveEmailVerification(savedEmailVerification);
     }
 }

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationRepository.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationRepository.java
@@ -6,11 +6,9 @@ import java.util.Optional;
 
 public interface EmailVerificationRepository {
 
-    void appendEmailVerification(EmailVerification emailVerification);
+    void saveEmailVerification(EmailVerification emailVerification);
 
     Optional<EmailVerification> findByUserEmail(UserEmail userEmail);
 
     boolean existsByUserEmail(UserEmail userEmail);
-
-    void modifyEmailVerification(EmailVerification emailVerification);
 }

--- a/src/main/java/com/naribackend/core/auth/VerificationCode.java
+++ b/src/main/java/com/naribackend/core/auth/VerificationCode.java
@@ -29,4 +29,20 @@ public class VerificationCode {
     public String toString() {
         return code;
     }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null || getClass() != obj.getClass()) return false;
+        if( obj.hashCode() != this.hashCode() ) return false;
+        if (this == obj) return true;
+
+        VerificationCode that = (VerificationCode) obj;
+
+        return code.equals(that.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return code.hashCode();
+    }
 }

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationEntityRepository.java
@@ -15,7 +15,7 @@ public class EmailVerificationEntityRepository implements EmailVerificationRepos
     private final EmailVerificationJpaRepository emailVerificationJpaRepository;
 
     @Override
-    public void appendEmailVerification(final EmailVerification emailVerification) {
+    public void saveEmailVerification(final EmailVerification emailVerification) {
         EmailVerificationEntity emailVerificationEntity = EmailVerificationEntity.from(emailVerification);
 
         emailVerificationJpaRepository.save(emailVerificationEntity);
@@ -31,12 +31,5 @@ public class EmailVerificationEntityRepository implements EmailVerificationRepos
     @Override
     public boolean existsByUserEmail(UserEmail userEmail) {
         return emailVerificationJpaRepository.existsByUserEmail(userEmail.getAddress());
-    }
-
-    @Override
-    public void modifyEmailVerification(EmailVerification emailVerification) {
-        EmailVerificationEntity emailVerificationEntity = EmailVerificationEntity.from(emailVerification);
-
-        emailVerificationJpaRepository.save(emailVerificationEntity);
     }
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -11,9 +11,10 @@ public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
     SEND_EMAIL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "이메일 전송에 실패했습니다.", LogLevel.ERROR),
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 이메일 형식입니다.", LogLevel.INFO),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 입력 값입니다.", LogLevel.INFO),
-    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, ErrorCode.E400, "이메일을 찾을 수 없습니다.", LogLevel.INFO)
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 이메일 형식입니다.", LogLevel.DEBUG),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 입력 값입니다.", LogLevel.DEBUG),
+    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, ErrorCode.E400, "이메일을 찾을 수 없습니다.", LogLevel.DEBUG),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 인증 코드입니다.", LogLevel.DEBUG),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- close #3 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 이메일 인증 번호 검증 기능 추가
- 사용자가 인증 받고자하는 이메일 주소와 인증 번호를 입력으로 받았을 때 검증하는 기능을 추가했어요 
- 다음 주소에서 기능을 테스트할 수 있어요 [인증 코드 확인 API 바로가기](https://api.nari-web.com/swagger-ui/index.html#/auth-controller/checkVerificationCode)
2. append, modify 메서드 -> save로 통합
-  entity 추가, 수정을 save 메서드로 통합 했어요 (4861a0bf145dfb08c698743f957012580ef15877)


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 
