### PR TITLE
Feat jwt login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
     implementation 'org.springframework.retry:spring-retry'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/naribackend/api/auth/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/naribackend/api/auth/CurrentUserArgumentResolver.java
@@ -1,0 +1,66 @@
+package com.naribackend.api.auth;
+
+import com.naribackend.core.auth.AccessTokenHandler;
+import com.naribackend.core.auth.CurrentUser;
+import com.naribackend.core.auth.LoginUser;
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Objects;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * {@code @CurrentUser LoginUser user} 매개변수에
+ * Authorization 헤더의 Bearer 토큰을 파싱해 만든 LoginUser 를 그대로 주입한다.
+ *
+ */
+@Component
+@RequiredArgsConstructor
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /** JWT 검증·파싱만 담당 */
+    private final AccessTokenHandler accessTokenHandler;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(LoginUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            @NonNull MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = resolveToken(Objects.requireNonNull(request));
+
+        if (accessToken == null || !accessTokenHandler.validate(accessToken)) {
+            throw new CoreException(ErrorType.AUTHENTICATION_FAIL);
+        }
+
+        long id = accessTokenHandler.getUserIdFrom(accessToken);
+
+        return LoginUser.builder()
+                .id(id)
+                .build();
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        return (bearer != null && bearer.startsWith("Bearer "))
+                ? bearer.substring(7)
+                : null;
+    }
+}

--- a/src/main/java/com/naribackend/api/auth/v1/AuthController.java
+++ b/src/main/java/com/naribackend/api/auth/v1/AuthController.java
@@ -2,13 +2,18 @@ package com.naribackend.api.auth.v1;
 
 import com.naribackend.api.auth.v1.request.CheckVerificationCodeRequest;
 import com.naribackend.api.auth.v1.request.CreateUserAccountRequest;
+import com.naribackend.api.auth.v1.request.GetAccessTokenRequest;
 import com.naribackend.api.auth.v1.request.SendVerificationCodeRequest;
+import com.naribackend.api.auth.v1.response.GetAccessTokenResponse;
 import com.naribackend.core.auth.AuthService;
 import com.naribackend.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -55,5 +60,20 @@ public class AuthController {
         authService.signUp(request.toUserEmail(), request.toRawUserPassword(), request.newNickname());
 
         return ApiResponse.success();
+    }
+
+    @Operation(
+            summary = "로그인",
+            description = "로그인을 하고 Access Token을 발급받습니다."
+    )
+    @PostMapping("/sign-in/access-token")
+    public ApiResponse<?> signIn(
+            @RequestBody @Valid final GetAccessTokenRequest request
+    ) {
+        String accessToken = authService.createAccessToken(request.toUserEmail(), request.toRawUserPassword());
+
+        return ApiResponse.success(
+                new GetAccessTokenResponse(accessToken)
+        );
     }
 }

--- a/src/main/java/com/naribackend/api/auth/v1/AuthController.java
+++ b/src/main/java/com/naribackend/api/auth/v1/AuthController.java
@@ -5,15 +5,16 @@ import com.naribackend.api.auth.v1.request.CreateUserAccountRequest;
 import com.naribackend.api.auth.v1.request.GetAccessTokenRequest;
 import com.naribackend.api.auth.v1.request.SendVerificationCodeRequest;
 import com.naribackend.api.auth.v1.response.GetAccessTokenResponse;
+import com.naribackend.api.auth.v1.response.GetUserInfoResponse;
 import com.naribackend.core.auth.AuthService;
+import com.naribackend.core.auth.CurrentUser;
+import com.naribackend.core.auth.LoginUser;
+import com.naribackend.core.auth.UserAccount;
 import com.naribackend.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -75,5 +76,17 @@ public class AuthController {
         return ApiResponse.success(
                 new GetAccessTokenResponse(accessToken)
         );
+    }
+
+    @Operation(
+            summary = "사용자 정보 조회",
+            description = "사용자 정보를 조회합니다."
+    )
+    @GetMapping("/me")
+    public ApiResponse<?> getMe(@CurrentUser LoginUser loginUser) {
+        UserAccount currentUserAccount = authService.getUserAccountBy(loginUser);
+        GetUserInfoResponse loginUserInfo = GetUserInfoResponse.from(currentUserAccount);
+
+        return ApiResponse.success(loginUserInfo);
     }
 }

--- a/src/main/java/com/naribackend/api/auth/v1/request/GetAccessTokenRequest.java
+++ b/src/main/java/com/naribackend/api/auth/v1/request/GetAccessTokenRequest.java
@@ -1,26 +1,27 @@
 package com.naribackend.api.auth.v1.request;
 
-import com.naribackend.core.auth.VerificationCode;
+import com.naribackend.core.auth.RawUserPassword;
 import com.naribackend.core.email.UserEmail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record CheckVerificationCodeRequest (
+public record GetAccessTokenRequest(
+
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         @Schema(description = "인증 코드를 받을 이메일 주소", example = "user@example.com")
-        String targetEmail,
+        String email,
 
-        @NotBlank(message = "인증 코드는 필수입니다.")
-        @Schema(description = "입력 받은 인증 코드", example = "123456")
-        String verificationCode
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Schema(description = "비밀번호", example = "password1234")
+        String password
 ){
     public UserEmail toUserEmail() {
-        return UserEmail.from(targetEmail);
+        return UserEmail.from(email);
     }
 
-    public VerificationCode toVerificationCode() {
-        return VerificationCode.from(verificationCode);
+    public RawUserPassword toRawUserPassword() {
+        return RawUserPassword.from(password);
     }
 }

--- a/src/main/java/com/naribackend/api/auth/v1/response/GetAccessTokenResponse.java
+++ b/src/main/java/com/naribackend/api/auth/v1/response/GetAccessTokenResponse.java
@@ -1,0 +1,6 @@
+package com.naribackend.api.auth.v1.response;
+
+public record GetAccessTokenResponse(
+        String accessToken
+){
+}

--- a/src/main/java/com/naribackend/api/auth/v1/response/GetUserInfoResponse.java
+++ b/src/main/java/com/naribackend/api/auth/v1/response/GetUserInfoResponse.java
@@ -1,0 +1,19 @@
+package com.naribackend.api.auth.v1.response;
+
+import com.naribackend.core.auth.UserAccount;
+import lombok.Builder;
+
+@Builder
+public record GetUserInfoResponse (
+        Long id,
+        String nickname,
+        String email
+){
+    public static GetUserInfoResponse from(UserAccount currentUserAccount) {
+        return GetUserInfoResponse.builder()
+                .id(currentUserAccount.getId())
+                .nickname(currentUserAccount.getNickname())
+                .email(currentUserAccount.getEmail().getAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/config/OpenApiConfig.java
+++ b/src/main/java/com/naribackend/config/OpenApiConfig.java
@@ -1,10 +1,22 @@
 package com.naribackend.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT")
+@OpenAPIDefinition(
+        security = @SecurityRequirement(name = "bearerAuth")
+)
 public class OpenApiConfig {
 
     @Bean

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.naribackend.security;
+package com.naribackend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +24,8 @@ public class SecurityConfig {
                             "/api/v1/auth/email-verification-code",
                             "/api/v1/auth/email-verification-code/check",
                             "/api/v1/auth/sign-up",
-                            "/api/v1/auth/sign-in/access-token"
+                            "/api/v1/auth/sign-in/access-token",
+                            "/api/v1/auth/me"
                     ).permitAll()
                     .requestMatchers(
                             "/v3/api-docs/**",
@@ -43,7 +44,7 @@ public class SecurityConfig {
         config.setAllowedOrigins(
                 List.of(
                         "https://nari-web.com", "https://api.nari-web.com", "https://www.nari-web.com",
-                        "http://localhost:3000", "http://localhost:5173"
+                        "http://localhost:3000"
                 )
         );
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -23,7 +23,8 @@ public class SecurityConfig {
                     .requestMatchers(
                             "/api/v1/auth/email-verification-code",
                             "/api/v1/auth/email-verification-code/check",
-                            "/api/v1/auth/sign-up"
+                            "/api/v1/auth/sign-up",
+                            "/api/v1/auth/sign-in/access-token"
                     ).permitAll()
                     .requestMatchers(
                             "/v3/api-docs/**",

--- a/src/main/java/com/naribackend/config/WebConfig.java
+++ b/src/main/java/com/naribackend/config/WebConfig.java
@@ -1,11 +1,20 @@
 package com.naribackend.config;
 
+import com.naribackend.api.auth.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.ForwardedHeaderFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
-public class WebConfig {
+@RequiredArgsConstructor
+public class WebConfig  implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
 
     /**
      * ForwardedHeaderFilter is used to handle the X-Forwarded-* headers
@@ -16,5 +25,10 @@ public class WebConfig {
     @Bean
     public ForwardedHeaderFilter forwardedHeaderFilter() {
         return new ForwardedHeaderFilter();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
     }
 }

--- a/src/main/java/com/naribackend/core/auth/AccessTokenHandler.java
+++ b/src/main/java/com/naribackend/core/auth/AccessTokenHandler.java
@@ -1,0 +1,10 @@
+package com.naribackend.core.auth;
+
+public interface AccessTokenHandler {
+
+    String createTokenBy(Long userId);
+
+    Long getUserIdFrom(String token);
+
+    boolean isTokenExpired(String token);
+}

--- a/src/main/java/com/naribackend/core/auth/AccessTokenHandler.java
+++ b/src/main/java/com/naribackend/core/auth/AccessTokenHandler.java
@@ -2,9 +2,11 @@ package com.naribackend.core.auth;
 
 public interface AccessTokenHandler {
 
-    String createTokenBy(Long userId);
+    String createTokenBy(long userId);
 
-    Long getUserIdFrom(String token);
+    long getUserIdFrom(String token);
 
     boolean isTokenExpired(String token);
+
+    boolean validate(String token);
 }

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -87,4 +87,10 @@ public class AuthService {
 
         return accessTokenHandler.createTokenBy(userAccount.getId());
     }
+
+    public UserAccount getUserAccountBy(final LoginUser loginUser) {
+        return userAccountRepository.findById(loginUser.getId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_EMAIL));
+    }
+
 }

--- a/src/main/java/com/naribackend/core/auth/CurrentUser.java
+++ b/src/main/java/com/naribackend/core/auth/CurrentUser.java
@@ -1,0 +1,8 @@
+package com.naribackend.core.auth;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser { }

--- a/src/main/java/com/naribackend/core/auth/LoginUser.java
+++ b/src/main/java/com/naribackend/core/auth/LoginUser.java
@@ -1,0 +1,13 @@
+package com.naribackend.core.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class LoginUser {
+
+    private final long id;
+}

--- a/src/main/java/com/naribackend/core/auth/RawUserPassword.java
+++ b/src/main/java/com/naribackend/core/auth/RawUserPassword.java
@@ -26,7 +26,10 @@ public class RawUserPassword {
         return new RawUserPassword(raw);
     }
 
-    public void matches(final UserPasswordEncoder userPasswordEncoder, final EncodedUserPassword encodedUserPassword) {
+    public void matches(
+            final UserPasswordEncoder userPasswordEncoder,
+            final EncodedUserPassword encodedUserPassword
+    ) {
         if (!userPasswordEncoder.matches(raw, encodedUserPassword.getEncodedPassword())) {
             throw new CoreException(ErrorType.INVALID_PASSWORD);
         }

--- a/src/main/java/com/naribackend/core/auth/UserAccountRepository.java
+++ b/src/main/java/com/naribackend/core/auth/UserAccountRepository.java
@@ -10,4 +10,6 @@ public interface UserAccountRepository {
     boolean existsByEmail(UserEmail email);
 
     Optional<UserAccount> findByEmail(UserEmail userEmail);
+
+    Optional<UserAccount> findById(Long id);
 }

--- a/src/main/java/com/naribackend/core/auth/UserAccountRepository.java
+++ b/src/main/java/com/naribackend/core/auth/UserAccountRepository.java
@@ -2,7 +2,12 @@ package com.naribackend.core.auth;
 
 import com.naribackend.core.email.UserEmail;
 
+import java.util.Optional;
+
 public interface UserAccountRepository {
     void saveUserAccount(UserAccount userAccount);
+
     boolean existsByEmail(UserEmail email);
+
+    Optional<UserAccount> findByEmail(UserEmail userEmail);
 }

--- a/src/main/java/com/naribackend/infra/auth/AccessTokenHandlerImpl.java
+++ b/src/main/java/com/naribackend/infra/auth/AccessTokenHandlerImpl.java
@@ -1,0 +1,76 @@
+package com.naribackend.infra.auth;
+
+import com.naribackend.core.auth.AccessTokenHandler;
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class AccessTokenHandlerImpl implements AccessTokenHandler {
+
+    private final SecretKey secretKey;
+
+    private final long expireSec;
+
+    public AccessTokenHandlerImpl(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expire-sec}") long expireSec)
+    {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expireSec = expireSec;
+    }
+
+    @Override
+    public String createTokenBy(Long userId) {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(expireSec)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+
+    @Override
+    public Long getUserIdFrom(String token) {
+        try {
+            Claims claims = Jwts.parser().verifyWith(secretKey)
+                    .build().parseSignedClaims(token).getPayload();
+
+            String userIdStr = claims.getSubject();
+
+            return Long.valueOf(userIdStr);
+        } catch (NumberFormatException e) {
+            log.error("userId를 Long으로 변경하는 과정에서 에러가 발생하였습니다. 빨리 확인 바랍니다.", e);
+            throw new CoreException(ErrorType.AUTHENTICATION_FAIL, e);
+        }
+        catch (Exception e) {
+            throw new CoreException(ErrorType.AUTHENTICATION_FAIL);
+        }
+    }
+
+    @Override
+    public boolean isTokenExpired(String token) {
+        Date expiration = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+
+        return expiration.before(new Date());
+    }
+}

--- a/src/main/java/com/naribackend/infra/auth/AccessTokenHandlerImpl.java
+++ b/src/main/java/com/naribackend/infra/auth/AccessTokenHandlerImpl.java
@@ -90,6 +90,6 @@ public class AccessTokenHandlerImpl implements AccessTokenHandler {
                 .getPayload()
                 .getExpiration();
 
-        return expiration.after(new Date());
+        return expiration.before(new Date());
     }
 }

--- a/src/main/java/com/naribackend/infra/mail/SmtpEmailSender.java
+++ b/src/main/java/com/naribackend/infra/mail/SmtpEmailSender.java
@@ -1,7 +1,7 @@
 package com.naribackend.infra.mail;
 
-import com.naribackend.core.email.EmailSender;
 import com.naribackend.core.email.EmailMessage;
+import com.naribackend.core.email.EmailSender;
 import com.naribackend.support.error.CoreException;
 import com.naribackend.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/naribackend/security/SecurityConfig.java
+++ b/src/main/java/com/naribackend/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.naribackend.config;
+package com.naribackend.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,7 +43,7 @@ public class SecurityConfig {
         config.setAllowedOrigins(
                 List.of(
                         "https://nari-web.com", "https://api.nari-web.com", "https://www.nari-web.com",
-                        "http://localhost:3000"
+                        "http://localhost:3000", "http://localhost:5173"
                 )
         );
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/com/naribackend/storage/auth/UserAccountEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/UserAccountEntityRepository.java
@@ -31,4 +31,10 @@ public class UserAccountEntityRepository implements UserAccountRepository {
         return userAccountJpaRepository.findByUserEmail(userEmail.getAddress())
                 .map(UserAccountEntity::toUserAccount);
     }
+
+    @Override
+    public Optional<UserAccount> findById(Long id) {
+        return userAccountJpaRepository.findById(id)
+                .map(UserAccountEntity::toUserAccount);
+    }
 }

--- a/src/main/java/com/naribackend/storage/auth/UserAccountEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/UserAccountEntityRepository.java
@@ -6,6 +6,8 @@ import com.naribackend.core.email.UserEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class UserAccountEntityRepository implements UserAccountRepository {
@@ -22,5 +24,11 @@ public class UserAccountEntityRepository implements UserAccountRepository {
     @Override
     public boolean existsByEmail(final UserEmail email) {
         return userAccountJpaRepository.existsByUserEmail(email.getAddress());
+    }
+
+    @Override
+    public Optional<UserAccount> findByEmail(UserEmail userEmail) {
+        return userAccountJpaRepository.findByUserEmail(userEmail.getAddress())
+                .map(UserAccountEntity::toUserAccount);
     }
 }

--- a/src/main/java/com/naribackend/storage/auth/UserAccountJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/UserAccountJpaRepository.java
@@ -2,8 +2,11 @@ package com.naribackend.storage.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserAccountJpaRepository extends JpaRepository<UserAccountEntity, Long> {
 
     boolean existsByUserEmail(String userEmail);
 
+    Optional<UserAccountEntity> findByUserEmail(String userEmail);
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -17,7 +17,8 @@ public enum ErrorType {
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 인증 코드입니다.", LogLevel.DEBUG),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘 못된 비밀번호 형식입니다.", LogLevel.DEBUG),
     NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증이 되지 않은 이메일 입니다.", LogLevel.DEBUG),
-    ALEADY_SIGNED_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 가입된 이메일입니다.", LogLevel.DEBUG),
+    ALREADY_SIGNED_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 가입된 이메일입니다.", LogLevel.DEBUG),
+    AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증에 실패 하였습니다.", LogLevel.DEBUG)
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- close #5 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 로그인 요청하면 access token을 발급하는 기능을 추가하였어요 f46f4ee430e1b17e0ee04985e84067eeb798047c
- 다음과 같은 상황에서 인증이 실패하고 메시지를 반환해요
    - 존재하지 않는 이메일 요청
    - 이메일과 비밀번호 불일치
- 만약 인증에 성공하면 access token을 반환해요
- access token은 10시간 유효하고 그 이상이 지나면 인증에 실패해요 
2. 사용자 정보 조회 기능 추가
- header의 Authorization에 access token을 넣어서 사용자 정보를 요청하면, access token을 확인하고 반환하는 기능을 추가하였어요
- 이 기능을 통해 프론트에서 백엔드로 인증이 잘 되는지 확인할 수 있어요


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- access token은 유출되지 않게 잘 관리해야해요. 이 부분은 추후 Refresh Token 등을 도입해서 해결할 예정이에요