### PR TITLE
[feat] logback 설정 및 docker 컨테이너 실행시 로그 저장 위치 설정 (close #11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM openjdk:17-jdk-slim
+
+RUN groupadd --system spring && useradd --system --create-home --gid spring spring
+RUN mkdir -p /var/log/app/spring && chown -R spring:spring /var/log/app/spring
+
 WORKDIR /app
 
 ARG JAR_FILE=build/libs/NARI-Backend-0.0.1-SNAPSHOT.jar
-COPY ${JAR_FILE} ./app.jar
+COPY --chown=spring:spring ${JAR_FILE} app.jar
 
-# 앱이 사용할 포트
+USER spring
+
 EXPOSE 8080
-
-# 컨테이너 시작 시 실행할 명령
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # NARI-Backend
+
+## Docker 
+### Docker Image 설치
+```bash
+docker run -d   --name nari-app -v /var/log/app/spring:/var/log/app/spring  -p 80:8080   gorani41/nari-app:latest
+```
+
+## 로그
+### 로그 저장 
+현재 NARI프로젝트는 logback을 사용하여 파일로 로그를 남기고 있어요
+
+
+### 로그 관련 설정 파일
+- src/main/resources/logback-spring.xml - 로그 설정 파일
+- application.yml - 로그 파일 위치 설정
+
+### 로그 저장 방법
+현재 로그 설정대로 로그를 남기기 위해서는 아래의 명령어를 통해 로그 디렉토리를 생성해야 해요
+```
+sudo mkdir -p /var/log/app/spring
+sudo chmod 777 /var/log/app/spring         
+```

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ docker run -d   --name nari-app -v /var/log/app/spring:/var/log/app/spring  -p 8
 현재 로그 설정대로 로그를 남기기 위해서는 아래의 명령어를 통해 로그 디렉토리를 생성해야 해요
 ```
 sudo mkdir -p /var/log/app/spring
-sudo chmod 777 /var/log/app/spring         
+sudo chown $USER:$USER /var/log/app/spring
+sudo chmod 750 /var/log/app/spring         
 ```

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+
+    <!-- Spring Boot의 application.yml 값 사용 -->
+    <property name="LOG_PATH" value="${LOG_FILE:-app.log}"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- #11 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. logback으로 로그 파일 저장 기능 추가 
로그는 RollingFileAppender를 사용해 일자별로 자동으로 롤링돼요. 이전 날짜의 로그는 .gz 형식으로 압축되어 저장되고, 예를 들어 하루가 지나면 app.log.2025-05-01.gz처럼 압축된 파일로 남게 돼요. 이렇게 저장된 로그는 최대 30일 동안 보관돼요. 로그 메시지에는 로그 발생 시간, 로그 레벨, 클래스명, 메시지 내용 등이 포함되며, 전체 로그 레벨은 INFO 이상만 기록되도록 설정돼 있어요.
2. 도커 파일 로그 파일 관련 기능 추가 
spring이라는 시스템 그룹과 유저를 생성하고, 로그 파일을 저장할 `/var/log/app/spring` 디렉터리를 만들고 해당 경로의 소유자를 spring 유저로 변경되도록 하였어요


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- application.yml에 아래에 형식대로 로그 경로, 파일을 지정해야 해요. 만약 지정하지 않는 다면 로그백 설정파일을 직접 수정해야 해요
```
logging:
  file:
    name: /var/log/app/spring/app.log

```