### PR TITLE
Feat/17 validation code expire

### DIFF
--- a/src/main/java/com/naribackend/api/ApiControllerAdvice.java
+++ b/src/main/java/com/naribackend/api/ApiControllerAdvice.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth;
+package com.naribackend.api;
 
 import com.naribackend.support.error.CoreException;
 import com.naribackend.support.error.ErrorMessage;

--- a/src/main/java/com/naribackend/api/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/naribackend/api/CurrentUserArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth;
+package com.naribackend.api;
 
 import com.naribackend.core.auth.AccessTokenHandler;
 import com.naribackend.core.auth.CurrentUser;

--- a/src/main/java/com/naribackend/api/v1/auth/AuthController.java
+++ b/src/main/java/com/naribackend/api/v1/auth/AuthController.java
@@ -1,11 +1,11 @@
-package com.naribackend.api.auth.v1;
+package com.naribackend.api.v1.auth;
 
-import com.naribackend.api.auth.v1.request.CheckVerificationCodeRequest;
-import com.naribackend.api.auth.v1.request.CreateUserAccountRequest;
-import com.naribackend.api.auth.v1.request.GetAccessTokenRequest;
-import com.naribackend.api.auth.v1.request.SendVerificationCodeRequest;
-import com.naribackend.api.auth.v1.response.GetAccessTokenResponse;
-import com.naribackend.api.auth.v1.response.GetUserInfoResponse;
+import com.naribackend.api.v1.auth.request.CheckVerificationCodeRequest;
+import com.naribackend.api.v1.auth.request.CreateUserAccountRequest;
+import com.naribackend.api.v1.auth.request.GetAccessTokenRequest;
+import com.naribackend.api.v1.auth.request.SendVerificationCodeRequest;
+import com.naribackend.api.v1.auth.response.GetAccessTokenResponse;
+import com.naribackend.api.v1.auth.response.GetUserInfoResponse;
 import com.naribackend.core.auth.AuthService;
 import com.naribackend.core.auth.CurrentUser;
 import com.naribackend.core.auth.LoginUser;

--- a/src/main/java/com/naribackend/api/v1/auth/request/CheckVerificationCodeRequest.java
+++ b/src/main/java/com/naribackend/api/v1/auth/request/CheckVerificationCodeRequest.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth.v1.request;
+package com.naribackend.api.v1.auth.request;
 
 import com.naribackend.core.auth.VerificationCode;
 import com.naribackend.core.email.UserEmail;

--- a/src/main/java/com/naribackend/api/v1/auth/request/CreateUserAccountRequest.java
+++ b/src/main/java/com/naribackend/api/v1/auth/request/CreateUserAccountRequest.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth.v1.request;
+package com.naribackend.api.v1.auth.request;
 
 import com.naribackend.core.auth.RawUserPassword;
 import com.naribackend.core.email.UserEmail;

--- a/src/main/java/com/naribackend/api/v1/auth/request/GetAccessTokenRequest.java
+++ b/src/main/java/com/naribackend/api/v1/auth/request/GetAccessTokenRequest.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth.v1.request;
+package com.naribackend.api.v1.auth.request;
 
 import com.naribackend.core.auth.RawUserPassword;
 import com.naribackend.core.email.UserEmail;

--- a/src/main/java/com/naribackend/api/v1/auth/request/SendVerificationCodeRequest.java
+++ b/src/main/java/com/naribackend/api/v1/auth/request/SendVerificationCodeRequest.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth.v1.request;
+package com.naribackend.api.v1.auth.request;
 
 import com.naribackend.core.email.UserEmail;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/naribackend/api/v1/auth/response/GetAccessTokenResponse.java
+++ b/src/main/java/com/naribackend/api/v1/auth/response/GetAccessTokenResponse.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth.v1.response;
+package com.naribackend.api.v1.auth.response;
 
 public record GetAccessTokenResponse(
         String accessToken

--- a/src/main/java/com/naribackend/api/v1/auth/response/GetUserInfoResponse.java
+++ b/src/main/java/com/naribackend/api/v1/auth/response/GetUserInfoResponse.java
@@ -1,4 +1,4 @@
-package com.naribackend.api.auth.v1.response;
+package com.naribackend.api.v1.auth.response;
 
 import com.naribackend.core.auth.UserAccount;
 import lombok.Builder;

--- a/src/main/java/com/naribackend/config/JpaAuditingConfig.java
+++ b/src/main/java/com/naribackend/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.naribackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/naribackend/config/WebConfig.java
+++ b/src/main/java/com/naribackend/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.naribackend.config;
 
-import com.naribackend.api.auth.CurrentUserArgumentResolver;
+import com.naribackend.api.CurrentUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/naribackend/core/DateTimeProvider.java
+++ b/src/main/java/com/naribackend/core/DateTimeProvider.java
@@ -1,0 +1,13 @@
+package com.naribackend.core;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class DateTimeProvider {
+
+    public LocalDateTime getCurrentDateTime() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.naribackend.core.auth;
 
+import com.naribackend.core.DateTimeProvider;
 import com.naribackend.core.email.EmailMessage;
 import com.naribackend.core.email.EmailSender;
 import com.naribackend.core.email.UserEmail;
@@ -28,6 +29,8 @@ public class AuthService {
 
     private final AccessTokenHandler accessTokenHandler;
 
+    private final DateTimeProvider dateTimeProvider;
+
     private final static long EMAIL_VERIFICATION_TTL = 60 * 5;
 
     public void processVerificationCode(final UserEmail toUserEmail) {
@@ -50,7 +53,7 @@ public class AuthService {
             final UserEmail targetEmail,
             final VerificationCode verificationCode
     ) {
-        final LocalDateTime verificationArrivalTime = LocalDateTime.now();
+        LocalDateTime verificationArrivalTime = dateTimeProvider.getCurrentDateTime();
 
         final EmailVerification savedEmailVerification = emailVerificationRepository.findByUserEmail(targetEmail)
                 .orElseThrow(

--- a/src/main/java/com/naribackend/core/auth/EmailVerification.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerification.java
@@ -1,10 +1,10 @@
 package com.naribackend.core.auth;
 
 import com.naribackend.core.email.UserEmail;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -16,18 +16,21 @@ public class EmailVerification {
     private final UserEmail userEmail;
     private VerificationCode verificationCode;
     private boolean isVerified;
+    private LocalDateTime modifiedAt;
 
     @Builder
     public EmailVerification(
         final Long id,
         final UserEmail userEmail,
         final VerificationCode verificationCode,
-        final boolean isVerified
+        final boolean isVerified,
+        final LocalDateTime modifiedAt
     ) {
         this.id = id;
         this.userEmail = userEmail;
         this.verificationCode = verificationCode;
         this.isVerified = isVerified;
+        this.modifiedAt = modifiedAt;
     }
 
     public void updateVerificationCode(final VerificationCode newVerificationCode) {
@@ -48,5 +51,9 @@ public class EmailVerification {
 
     public void markAsVerified() {
         this.isVerified = true;
+    }
+
+    public long secondsSinceModified(LocalDateTime other) {
+        return Math.abs(Duration.between(this.modifiedAt, other).getSeconds());
     }
 }

--- a/src/main/java/com/naribackend/storage/BaseEntity.java
+++ b/src/main/java/com/naribackend/storage/BaseEntity.java
@@ -23,6 +23,6 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationEntity.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationEntity.java
@@ -46,6 +46,7 @@ public class EmailVerificationEntity extends BaseEntity {
                 .userEmail(UserEmail.from(userEmail))
                 .verificationCode(VerificationCode.from(verificationCode))
                 .isVerified(isVerified)
+                .modifiedAt(this.getModifiedAt())
                 .build();
     }
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -19,7 +19,8 @@ public enum ErrorType {
     NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증이 되지 않은 이메일 입니다.", LogLevel.DEBUG),
     ALREADY_SIGNED_EMAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 가입된 이메일입니다.", LogLevel.DEBUG),
     AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증에 실패 하였습니다.", LogLevel.DEBUG),
-    BIND_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력 형식이 올바르지 않습니다.", LogLevel.DEBUG)
+    BIND_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력 형식이 올바르지 않습니다.", LogLevel.DEBUG),
+    EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증 코드가 만료되었습니다.", LogLevel.DEBUG),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
+++ b/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
@@ -1,10 +1,10 @@
 package com.naribackend.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.naribackend.api.auth.v1.request.CheckVerificationCodeRequest;
-import com.naribackend.api.auth.v1.request.CreateUserAccountRequest;
-import com.naribackend.api.auth.v1.request.GetAccessTokenRequest;
-import com.naribackend.api.auth.v1.request.SendVerificationCodeRequest;
+import com.naribackend.api.v1.auth.request.CheckVerificationCodeRequest;
+import com.naribackend.api.v1.auth.request.CreateUserAccountRequest;
+import com.naribackend.api.v1.auth.request.GetAccessTokenRequest;
+import com.naribackend.api.v1.auth.request.SendVerificationCodeRequest;
 import com.naribackend.core.auth.*;
 import com.naribackend.core.email.EmailSender;
 import com.naribackend.core.email.UserEmail;

--- a/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
+++ b/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
@@ -5,6 +5,7 @@ import com.naribackend.api.v1.auth.request.CheckVerificationCodeRequest;
 import com.naribackend.api.v1.auth.request.CreateUserAccountRequest;
 import com.naribackend.api.v1.auth.request.GetAccessTokenRequest;
 import com.naribackend.api.v1.auth.request.SendVerificationCodeRequest;
+import com.naribackend.core.DateTimeProvider;
 import com.naribackend.core.auth.*;
 import com.naribackend.core.email.EmailSender;
 import com.naribackend.core.email.UserEmail;
@@ -24,6 +25,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -61,6 +64,9 @@ class AuthIntegrationDocsTest {
 
     @Autowired
     AuthService authService;
+
+    @MockitoBean
+    DateTimeProvider dateTimeProvider;
 
     @MockitoBean
     EmailSender emailSender;
@@ -399,6 +405,9 @@ class AuthIntegrationDocsTest {
 
         VerificationCode verificationCode = emailVerification.getVerificationCode();
 
+        LocalDateTime verificationArrivalTime = LocalDateTime.now().plusMinutes(1);
+        when(dateTimeProvider.getCurrentDateTime()).thenReturn(verificationArrivalTime);
+
         // when & then
         mockMvc.perform(
                 RestDocumentationRequestBuilders.post("/api/v1/auth/email-verification-code/check")
@@ -426,6 +435,9 @@ class AuthIntegrationDocsTest {
         SendVerificationCodeRequest request = new SendVerificationCodeRequest("user@example.com");
         authService.processVerificationCode(request.toUserEmail());
 
+        LocalDateTime verificationArrivalTime = LocalDateTime.now().plusMinutes(1);
+        when(dateTimeProvider.getCurrentDateTime()).thenReturn(verificationArrivalTime);
+
         // when & then
         mockMvc.perform(
                         RestDocumentationRequestBuilders.post("/api/v1/auth/email-verification-code/check")
@@ -441,4 +453,37 @@ class AuthIntegrationDocsTest {
                 );
     }
 
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증 실패 - 만료된 인증 코드")
+    void checkVerificationCode_fail_expire_token() throws Exception {
+
+        // given
+        LocalDateTime verificationArrivalTime = LocalDateTime.now().plusMinutes(6);
+
+        SendVerificationCodeRequest request = new SendVerificationCodeRequest("user@example.com");
+        authService.processVerificationCode(request.toUserEmail());
+
+        EmailVerification emailVerification = emailVerificationRepository.findByUserEmail(request.toUserEmail())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_EMAIL));
+
+        VerificationCode verificationCode = emailVerification.getVerificationCode();
+
+        when(dateTimeProvider.getCurrentDateTime()).thenReturn(verificationArrivalTime);
+
+        // when & then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/api/v1/auth/email-verification-code/check")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                        new CheckVerificationCodeRequest(request.toEmail(), verificationCode.toString()))
+                                )
+                ).andExpect(status().is4xxClientError())
+                .andDo(document("email-verification-code-check",
+                        responseFields(
+                                ApiResponseDocs.ERROR_FIELDS()
+                        ))
+                );
+
+    }
 }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- close #17 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 테이블의 row가 변경될 때 마다 수정 날짜가 변경되도록 JpaAuditingConfig를 추가 했어요  fdd711b87edb2b6ccf2618b57106748bbc1356e6
2. 이메일 인증 코드 만료 기능을 추가했어요 459948bd70b4e8dd01bba0597a3498afd4d972d6
3. 이메일 인증 코드 만료 기능에 대한 테스트 코드를 추가했어요 459948bd70b4e8dd01bba0597a3498afd4d972d6


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 
