### PR TITLE
[feat] 닉네임 자동 생성 기능 추가

### DIFF
--- a/src/main/java/com/naribackend/api/v1/auth/AuthController.java
+++ b/src/main/java/com/naribackend/api/v1/auth/AuthController.java
@@ -61,7 +61,7 @@ public class AuthController {
     public ApiResponse<?> signUp(
             @RequestBody @Valid final CreateUserAccountRequest request
     ) {
-        authService.signUp(request.toUserEmail(), request.toRawUserPassword(), request.toNickName());
+        authService.signUp(request.toUserEmail(), request.toRawUserPassword(), request.toNickname());
 
         return ApiResponse.success();
     }

--- a/src/main/java/com/naribackend/api/v1/auth/AuthController.java
+++ b/src/main/java/com/naribackend/api/v1/auth/AuthController.java
@@ -61,7 +61,7 @@ public class AuthController {
     public ApiResponse<?> signUp(
             @RequestBody @Valid final CreateUserAccountRequest request
     ) {
-        authService.signUp(request.toUserEmail(), request.toRawUserPassword(), request.newNickname());
+        authService.signUp(request.toUserEmail(), request.toRawUserPassword(), request.toNickName());
 
         return ApiResponse.success();
     }

--- a/src/main/java/com/naribackend/api/v1/auth/request/CreateUserAccountRequest.java
+++ b/src/main/java/com/naribackend/api/v1/auth/request/CreateUserAccountRequest.java
@@ -1,10 +1,12 @@
 package com.naribackend.api.v1.auth.request;
 
 import com.naribackend.core.auth.RawUserPassword;
+import com.naribackend.core.auth.UserNickname;
 import com.naribackend.core.email.UserEmail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
 
 public record CreateUserAccountRequest (
         @NotBlank(message = "이메일은 필수입니다.")
@@ -16,7 +18,7 @@ public record CreateUserAccountRequest (
         @Schema(description = "비밀번호", example = "password1234")
         String newPassword,
 
-        @NotBlank(message = "닉네임은 필수입니다.")
+        @Length(max = 20, message = "닉네임은 20자 이하로 입력해주세요.")
         @Schema(description = "닉네임", example = "nickname")
         String newNickname
 ){
@@ -29,4 +31,7 @@ public record CreateUserAccountRequest (
         return RawUserPassword.from(newPassword);
     }
 
+    public UserNickname toNickName() {
+        return UserNickname.from(newNickname);
+    }
 }

--- a/src/main/java/com/naribackend/api/v1/auth/request/CreateUserAccountRequest.java
+++ b/src/main/java/com/naribackend/api/v1/auth/request/CreateUserAccountRequest.java
@@ -31,7 +31,7 @@ public record CreateUserAccountRequest (
         return RawUserPassword.from(newPassword);
     }
 
-    public UserNickname toNickName() {
+    public UserNickname toNickname() {
         return UserNickname.from(newNickname);
     }
 }

--- a/src/main/java/com/naribackend/api/v1/auth/response/GetUserInfoResponse.java
+++ b/src/main/java/com/naribackend/api/v1/auth/response/GetUserInfoResponse.java
@@ -12,7 +12,7 @@ public record GetUserInfoResponse (
     public static GetUserInfoResponse from(UserAccount currentUserAccount) {
         return GetUserInfoResponse.builder()
                 .id(currentUserAccount.getId())
-                .nickname(currentUserAccount.getNickname())
+                .nickname(currentUserAccount.getNickname().getNickname())
                 .email(currentUserAccount.getEmail().getAddress())
                 .build();
     }

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -74,7 +74,7 @@ public class AuthService {
     public void signUp(
             final UserEmail newUserEmail,
             final RawUserPassword newRawUserPassword,
-            final String newNickname
+            final UserNickname newNickname
     ) {
         if(!emailVerificationReader.isVerified(newUserEmail)) {
             throw new CoreException(ErrorType.NOT_VERIFIED_EMAIL);

--- a/src/main/java/com/naribackend/core/auth/UserAccount.java
+++ b/src/main/java/com/naribackend/core/auth/UserAccount.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class UserAccount {
     private final Long id;
 
-    private final String nickname;
+    private final UserNickname nickname;
 
     private final EncodedUserPassword encodedUserPassword;
 

--- a/src/main/java/com/naribackend/core/auth/UserAccountAppender.java
+++ b/src/main/java/com/naribackend/core/auth/UserAccountAppender.java
@@ -13,7 +13,7 @@ public class UserAccountAppender {
     public void appendUserAccount(
             final UserEmail newUserEmail,
             final EncodedUserPassword newEncodedUserPassword,
-            final String newNickname
+            final UserNickname newNickname
     ) {
         UserAccount newUserAccount = UserAccount.builder()
                 .email(newUserEmail)

--- a/src/main/java/com/naribackend/core/auth/UserNickname.java
+++ b/src/main/java/com/naribackend/core/auth/UserNickname.java
@@ -1,0 +1,50 @@
+package com.naribackend.core.auth;
+
+import lombok.Getter;
+
+import java.util.Random;
+
+@Getter
+public class UserNickname {
+
+    private final String nickname;
+
+    private static final Random RANDOM = new Random(System.currentTimeMillis());
+
+    private static final String[] FLOWERS = {
+            "장미", "백합", "국화", "튤립", "해바라기",
+            "라벤더", "코스모스", "카네이션", "민들레", "벚꽃"
+    };
+
+    private static final String[] ADJECTIVES = {
+            "아름다운", "싱그러운", "향기로운", "화사한", "청초한",
+            "고운", "햇살가득", "우아한", "푸르른", "산뜻한"
+    };
+
+    public UserNickname(String nickname) {
+        if (nickname == null || nickname.isEmpty()) {
+            this.nickname = generateRandomNickname();
+
+            return;
+        }
+
+        this.nickname = nickname;
+    }
+
+    private String generateRandomNickname() {
+        String adjective = ADJECTIVES[RANDOM.nextInt(ADJECTIVES.length)];
+        String flower = FLOWERS[RANDOM.nextInt(FLOWERS.length)];
+        int number = RANDOM.nextInt(1000, 10000); // 4자리 숫자
+
+        return adjective + flower + number;
+    }
+
+    @Override
+    public String toString() {
+        return "user nickname= " + nickname;
+    }
+
+    public static UserNickname from (final String nickname) {
+        return new UserNickname(nickname);
+    }
+}

--- a/src/main/java/com/naribackend/storage/auth/UserAccountEntity.java
+++ b/src/main/java/com/naribackend/storage/auth/UserAccountEntity.java
@@ -2,6 +2,7 @@ package com.naribackend.storage.auth;
 
 import com.naribackend.core.auth.EncodedUserPassword;
 import com.naribackend.core.auth.UserAccount;
+import com.naribackend.core.auth.UserNickname;
 import com.naribackend.core.email.UserEmail;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -31,7 +32,7 @@ public class UserAccountEntity {
 
     public static UserAccountEntity from(final UserAccount userAccount) {
         return UserAccountEntity.builder()
-                .nickname(userAccount.getNickname())
+                .nickname(userAccount.getNickname().getNickname())
                 .encodedUserPassword(userAccount.getEncodedUserPassword().getEncodedPassword())
                 .userEmail(userAccount.getEmail().getAddress())
                 .build();
@@ -40,7 +41,7 @@ public class UserAccountEntity {
     public UserAccount toUserAccount() {
         return UserAccount.builder()
                 .id(id)
-                .nickname(nickname)
+                .nickname(UserNickname.from(nickname))
                 .encodedUserPassword(EncodedUserPassword.from(encodedUserPassword))
                 .email(UserEmail.from(userEmail))
                 .build();

--- a/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
+++ b/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -132,7 +133,7 @@ class AuthIntegrationDocsTest {
         userAccountAppender.appendUserAccount(
                 userEmail,
                 encodedPassword,
-                "nickname"
+                UserNickname.from("nickname")
         );
 
         // when & then
@@ -171,7 +172,7 @@ class AuthIntegrationDocsTest {
         userAccountAppender.appendUserAccount(
                 userEmail,
                 encodedPassword,
-                "nickname"
+                UserNickname.from("nickname")
         );
 
         // when & then
@@ -228,7 +229,10 @@ class AuthIntegrationDocsTest {
                 requestFields(
                     fieldWithPath("newUserEmail").description("회원가입할 이메일"),
                     fieldWithPath("newPassword").description("회원가입할 비밀번호"),
-                    fieldWithPath("newNickname").description("회원가입할 닉네임")
+                    fieldWithPath("newNickname")
+                        .optional()
+                        .type(JsonFieldType.STRING)
+                        .description("회원가입할 닉네임(선택)")
                 ),
                 responseFields(
                     ApiResponseDocs.SUCCESS_FIELDS()
@@ -315,7 +319,7 @@ class AuthIntegrationDocsTest {
         userAccountAppender.appendUserAccount(
                 userEmail,
                 encodedPassword,
-                "nickname"
+                UserNickname.from("nickname")
         );
 
         String accessToken = authService.createAccessToken(userEmail, userPassword);
@@ -352,7 +356,7 @@ class AuthIntegrationDocsTest {
         userAccountAppender.appendUserAccount(
                 userEmail,
                 encodedPassword,
-                "nickname"
+                UserNickname.from("nickname")
         );
 
         AccessTokenHandlerImpl accessTokenHandler = new AccessTokenHandlerImpl("secretsecretsecretsecretsecretsecretsecretsecret", 0L);


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- Close #19

## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 회원가입 시 닉네임을 입력하지 않으면, 자동으로 닉네임이 생성되도록 기능 추가 하였어요85762d5b49b4714af267532cd22fd947de214da7
2. 자동 생성되는 이름 규칙은 "형용사 + 꽃이름 + 4자리 숫자" 이에요. 예로들면 "싱그러운코스모스7245" 이에요 

## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 
