### PR TITLE
[feat] 소프트 회원 탈퇴 기능 구현 (Close #20)

### DIFF
--- a/src/main/java/com/naribackend/api/v1/user/UserController.java
+++ b/src/main/java/com/naribackend/api/v1/user/UserController.java
@@ -1,0 +1,29 @@
+package com.naribackend.api.v1.user;
+
+import com.naribackend.core.auth.CurrentUser;
+import com.naribackend.core.auth.LoginUser;
+import com.naribackend.core.user.UserService;
+import com.naribackend.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @DeleteMapping("/me/withdrawal")
+    public ApiResponse<?> withdrawal(
+        @Parameter(hidden = true) @CurrentUser final LoginUser loginUser
+    ) {
+        userService.withdrawUserAccount(loginUser.getId());
+
+        return ApiResponse.success();
+    }
+
+}

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                             "/api/v1/auth/sign-up",
                             "/api/v1/auth/sign-in/access-token",
                             "/api/v1/auth/me",
-                            "api/v1/user/me/withdrawal"
+                            "/api/v1/user/me/withdrawal"
                     ).permitAll()
                     .requestMatchers(
                             "/v3/api-docs/**",

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
                             "/api/v1/auth/email-verification-code/check",
                             "/api/v1/auth/sign-up",
                             "/api/v1/auth/sign-in/access-token",
-                            "/api/v1/auth/me"
+                            "/api/v1/auth/me",
+                            "api/v1/user/me/withdrawal"
                     ).permitAll()
                     .requestMatchers(
                             "/v3/api-docs/**",

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -106,6 +106,10 @@ public class AuthService {
 
         rawUserPassword.matches(userPasswordEncoder, userAccount.getEncodedUserPassword());
 
+        if(userAccount.isUserWithdrawn()) {
+            throw new CoreException(ErrorType.WITHDRAWN_USER);
+        }
+
         return accessTokenHandler.createTokenBy(userAccount.getId());
     }
 

--- a/src/main/java/com/naribackend/core/auth/AuthService.java
+++ b/src/main/java/com/naribackend/core/auth/AuthService.java
@@ -31,7 +31,9 @@ public class AuthService {
 
     private final DateTimeProvider dateTimeProvider;
 
-    private final static long EMAIL_VERIFICATION_TTL = 60 * 5;
+    private final static long EMAIL_VERIFICATION_TTL = 60 * 5; // 인증 코드의 TTL은 5분
+
+    private final static long VERIFIED_EMAIL_VERIFICATION_TTL = 60 * 60; // 인증된 이메일의 TTL은 1시간
 
     public void processVerificationCode(final UserEmail toUserEmail) {
         final VerificationCode verificationCode = VerificationCode.generateSixDigitCode();
@@ -80,9 +82,15 @@ public class AuthService {
             throw new CoreException(ErrorType.NOT_VERIFIED_EMAIL);
         }
 
+        if(emailVerificationReader.isVerificationExpired(newUserEmail, dateTimeProvider.getCurrentDateTime(), VERIFIED_EMAIL_VERIFICATION_TTL)) {
+            throw new CoreException(ErrorType.EXPIRED_VERIFICATION_CODE);
+        }
+
         if(userAccountRepository.existsByEmail(newUserEmail)) {
             throw new CoreException(ErrorType.ALREADY_SIGNED_EMAIL);
         }
+
+        emailVerificationRepository.deleteByUserEmail(newUserEmail);
 
         EncodedUserPassword encodedUserPassword = newRawUserPassword.encode(userPasswordEncoder);
         userAccountAppender.appendUserAccount(

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationReader.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationReader.java
@@ -4,6 +4,9 @@ import com.naribackend.core.email.UserEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+
 @Component
 @RequiredArgsConstructor
 public class EmailVerificationReader {
@@ -14,5 +17,16 @@ public class EmailVerificationReader {
         return emailVerificationRepository.findByUserEmail(userEmail)
                 .map(EmailVerification::isVerified)
                 .orElse(false);
+    }
+
+    public boolean isVerificationExpired(final UserEmail userEmail, final LocalDateTime currentDateTime, final long maxSeconds) {
+        return emailVerificationRepository.findByUserEmail(userEmail)
+                .filter(emailVerification -> isOlderThanExpirySeconds(emailVerification.getModifiedAt(), currentDateTime, maxSeconds))
+                .isPresent();
+    }
+
+    private boolean isOlderThanExpirySeconds(final LocalDateTime modifiedAt, final LocalDateTime currentDateTime, final long expirySeconds) {
+        return Duration.between(modifiedAt, currentDateTime)
+                .compareTo(Duration.ofSeconds(expirySeconds)) > 0;
     }
 }

--- a/src/main/java/com/naribackend/core/auth/EmailVerificationRepository.java
+++ b/src/main/java/com/naribackend/core/auth/EmailVerificationRepository.java
@@ -11,4 +11,6 @@ public interface EmailVerificationRepository {
     Optional<EmailVerification> findByUserEmail(UserEmail userEmail);
 
     boolean existsByUserEmail(UserEmail userEmail);
+
+    void deleteByUserEmail(UserEmail userEmail);
 }

--- a/src/main/java/com/naribackend/core/auth/UserAccount.java
+++ b/src/main/java/com/naribackend/core/auth/UserAccount.java
@@ -1,6 +1,7 @@
 package com.naribackend.core.auth;
 
 import com.naribackend.core.email.UserEmail;
+import com.naribackend.core.user.WithdrawnDefaults;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,9 +10,20 @@ import lombok.Getter;
 public class UserAccount {
     private final Long id;
 
-    private final UserNickname nickname;
+    private UserNickname nickname;
 
-    private final EncodedUserPassword encodedUserPassword;
+    private EncodedUserPassword encodedUserPassword;
 
-    private final UserEmail email;
+    private UserEmail email;
+
+    private boolean isUserWithdrawn;
+
+    public void anonymizeWithdrawnUser() {
+        WithdrawnDefaults withdrawnDefaults = WithdrawnDefaults.of(id);
+
+        this.isUserWithdrawn = true;
+        this.nickname = withdrawnDefaults.nickname();
+        this.encodedUserPassword = withdrawnDefaults.encodedPassword();
+        this.email = withdrawnDefaults.email();
+    }
 }

--- a/src/main/java/com/naribackend/core/auth/UserAccount.java
+++ b/src/main/java/com/naribackend/core/auth/UserAccount.java
@@ -26,4 +26,8 @@ public class UserAccount {
         this.encodedUserPassword = withdrawnDefaults.encodedPassword();
         this.email = withdrawnDefaults.email();
     }
+
+    public boolean isUserWithdrawn() {
+        return isUserWithdrawn;
+    }
 }

--- a/src/main/java/com/naribackend/core/user/UserService.java
+++ b/src/main/java/com/naribackend/core/user/UserService.java
@@ -1,0 +1,24 @@
+package com.naribackend.core.user;
+
+import com.naribackend.core.auth.UserAccount;
+import com.naribackend.core.auth.UserAccountRepository;
+import com.naribackend.support.error.CoreException;
+import com.naribackend.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    public void withdrawUserAccount(final Long userId) {
+        UserAccount userAccount = userAccountRepository.findById(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_USER));
+
+        userAccount.anonymizeWithdrawnUser();
+
+        userAccountRepository.saveUserAccount(userAccount);
+    }
+}

--- a/src/main/java/com/naribackend/core/user/WithdrawnDefaults.java
+++ b/src/main/java/com/naribackend/core/user/WithdrawnDefaults.java
@@ -1,0 +1,41 @@
+package com.naribackend.core.user;
+
+import com.naribackend.core.auth.EncodedUserPassword;
+import com.naribackend.core.auth.UserNickname;
+import com.naribackend.core.email.UserEmail;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public record WithdrawnDefaults(
+        UserNickname nickname,
+        UserEmail email,
+        EncodedUserPassword encodedPassword
+) {
+    private static final SecureRandom RND = new SecureRandom();
+    private static final int SUFFIX_LEN   = 12;
+    private static final String ALPHA_NUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final BCryptPasswordEncoder ENCODER = new BCryptPasswordEncoder();
+
+    public static WithdrawnDefaults of(final long userId) {
+        String suffix = randomAlphaNum(SUFFIX_LEN);
+
+        UserNickname nick = UserNickname.from("탈퇴한회원_" + suffix);
+        UserEmail    mail = UserEmail.from("withdrawn+" + userId + "-" + suffix + "@nari-web.com");
+
+        String rawPw = UUID.randomUUID() + Base64.getEncoder().encodeToString(RND.generateSeed(16));
+        EncodedUserPassword pw = EncodedUserPassword.from(ENCODER.encode(rawPw));
+
+        return new WithdrawnDefaults(nick, mail, pw);
+    }
+
+    private static String randomAlphaNum(final int len) {
+        return RND.ints(len, 0, ALPHA_NUM.length())
+                .mapToObj(ALPHA_NUM::charAt)
+                .map(Object::toString)
+                .collect(Collectors.joining());
+    }
+}

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationEntityRepository.java
@@ -5,6 +5,7 @@ import com.naribackend.core.auth.EmailVerificationRepository;
 import com.naribackend.core.email.UserEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -22,14 +23,22 @@ public class EmailVerificationEntityRepository implements EmailVerificationRepos
     }
 
     @Override
-    public Optional<EmailVerification> findByUserEmail(UserEmail userEmail) {
+    public Optional<EmailVerification> findByUserEmail(final UserEmail userEmail) {
         String userEmailStr = userEmail.getAddress();
 
         return emailVerificationJpaRepository.findByUserEmail(userEmailStr).map(EmailVerificationEntity::toEmailVerification);
     }
 
     @Override
-    public boolean existsByUserEmail(UserEmail userEmail) {
+    public boolean existsByUserEmail(final UserEmail userEmail) {
         return emailVerificationJpaRepository.existsByUserEmail(userEmail.getAddress());
+    }
+
+    @Override
+    @Transactional
+    public void deleteByUserEmail(final UserEmail userEmail) {
+        String userEmailStr = userEmail.getAddress();
+
+        emailVerificationJpaRepository.deleteByUserEmail(userEmailStr);
     }
 }

--- a/src/main/java/com/naribackend/storage/auth/EmailVerificationJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/auth/EmailVerificationJpaRepository.java
@@ -9,4 +9,6 @@ public interface EmailVerificationJpaRepository extends JpaRepository<EmailVerif
     Optional<EmailVerificationEntity> findByUserEmail(String userEmail);
 
     boolean existsByUserEmail(String userEmail);
+
+    void deleteByUserEmail(String userEmail);
 }

--- a/src/main/java/com/naribackend/storage/auth/UserAccountEntity.java
+++ b/src/main/java/com/naribackend/storage/auth/UserAccountEntity.java
@@ -30,11 +30,16 @@ public class UserAccountEntity {
     @Column(name = "user_email", nullable = false)
     private String userEmail;
 
+    @Column(name = "is_user_withdrawn", nullable = false)
+    private boolean isUserWithdrawn;
+
     public static UserAccountEntity from(final UserAccount userAccount) {
         return UserAccountEntity.builder()
+                .id(userAccount.getId())
                 .nickname(userAccount.getNickname().getNickname())
                 .encodedUserPassword(userAccount.getEncodedUserPassword().getEncodedPassword())
                 .userEmail(userAccount.getEmail().getAddress())
+                .isUserWithdrawn(userAccount.isUserWithdrawn())
                 .build();
     }
 
@@ -44,6 +49,7 @@ public class UserAccountEntity {
                 .nickname(UserNickname.from(nickname))
                 .encodedUserPassword(EncodedUserPassword.from(encodedUserPassword))
                 .email(UserEmail.from(userEmail))
+                .isUserWithdrawn(isUserWithdrawn)
                 .build();
     }
 }

--- a/src/main/java/com/naribackend/support/error/ErrorCode.java
+++ b/src/main/java/com/naribackend/support/error/ErrorCode.java
@@ -2,5 +2,6 @@ package com.naribackend.support.error;
 
 public enum ErrorCode {
     E400,
+    E404,
     E500
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
     BIND_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력 형식이 올바르지 않습니다.", LogLevel.DEBUG),
     EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증 코드가 만료되었습니다.", LogLevel.DEBUG),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, ErrorCode.E404, "사용자를 찾을 수 없습니다.", LogLevel.DEBUG),
+    WITHDRAWN_USER(HttpStatus.BAD_REQUEST, ErrorCode.E400, "탈퇴한 사용자입니다.", LogLevel.ERROR),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -21,7 +21,7 @@ public enum ErrorType {
     AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증에 실패 하였습니다.", LogLevel.DEBUG),
     BIND_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력 형식이 올바르지 않습니다.", LogLevel.DEBUG),
     EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증 코드가 만료되었습니다.", LogLevel.DEBUG),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, ErrorCode.E400, "사용자를 찾을 수 없습니다.", LogLevel.ERROR),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, ErrorCode.E404, "사용자를 찾을 수 없습니다.", LogLevel.DEBUG),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
     AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증에 실패 하였습니다.", LogLevel.DEBUG),
     BIND_EXCEPTION(HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력 형식이 올바르지 않습니다.", LogLevel.DEBUG),
     EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, ErrorCode.E400, "인증 코드가 만료되었습니다.", LogLevel.DEBUG),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, ErrorCode.E400, "사용자를 찾을 수 없습니다.", LogLevel.ERROR),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
+++ b/src/test/java/com/naribackend/auth/AuthIntegrationDocsTest.java
@@ -207,6 +207,8 @@ class AuthIntegrationDocsTest {
 
         UserEmail newUserEmail = UserEmail.from(newEmail);
 
+        when(dateTimeProvider.getCurrentDateTime()).thenReturn(LocalDateTime.now());
+
         final VerificationCode verificationCode = VerificationCode.generateSixDigitCode();
         emailVerificationAppender.appendEmailVerification(newUserEmail, verificationCode);
 

--- a/src/test/java/com/naribackend/user/UserIntegrationDocsTest.java
+++ b/src/test/java/com/naribackend/user/UserIntegrationDocsTest.java
@@ -1,0 +1,89 @@
+package com.naribackend.user;
+
+import com.naribackend.core.auth.*;
+import com.naribackend.core.email.UserEmail;
+import com.naribackend.support.ApiResponseDocs;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+public class UserIntegrationDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserPasswordEncoder userPasswordEncoder;
+
+    @Autowired
+    private UserAccountAppender userAccountAppender;
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    @DisplayName("회원 탈퇴 API 성공 - 문서화")
+    void withdraw_user_account_success_docs() throws Exception {
+
+        // given
+        UserEmail userEmail = UserEmail.from("user1234@example.com");
+        String password = "password1234";
+        RawUserPassword userPassword = RawUserPassword.from(password);
+        EncodedUserPassword encodedPassword = userPassword.encode(userPasswordEncoder);
+
+        userAccountAppender.appendUserAccount(
+            userEmail,
+            encodedPassword,
+            UserNickname.from("nickname")
+        );
+
+        String accessToken = authService.createAccessToken(userEmail, userPassword);
+
+        // when & then
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.delete("/api/v1/user/me/withdrawal")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andDo(document("me-withdrawal",
+                responseFields(
+                    ApiResponseDocs.SUCCESS_FIELDS()
+                ))
+            );
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 API 실패 - 인증되지 않은 사용자")
+    void withdraw_user_account_fail_unauthenticated_docs() throws Exception {
+
+        // when & then
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.delete("/api/v1/user/me/withdrawal")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().is4xxClientError())
+            .andDo(document("me-withdrawal-unauthenticated",
+                responseFields(
+                    ApiResponseDocs.ERROR_FIELDS()
+                ))
+            );
+    }
+}


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- 연관된 이슈 번호를 작성해주세요.
- Close #20 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 회원 탈퇴 시 회원정보(이메일, 비밀번호, 닉네임)는 모두 비식별화 처리했고, 탈퇴 일시와 내부 식별자(ID)를 유지하도록 구현했어요.
2. 탈퇴한 계정의 데이터(글, 댓글 등)와의 연관성은 유지하면서 개인정보를 보호할 수 있도록 로직을 추가했어요.
3. 회원 탈퇴 성공/실패 테스트도 추가 했어요 


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 앞으로도 개인정보 비식별화 로직이 모든 경우에 정확하게 작동하는지 배포 후에도 추가 검증이 필요해요
