### PR TITLE
[feat, test]  이용한 가능한 talk 정보 조회 기능 추가 

### DIFF
--- a/src/main/java/com/naribackend/api/v1/credit/CreditController.java
+++ b/src/main/java/com/naribackend/api/v1/credit/CreditController.java
@@ -1,9 +1,12 @@
 package com.naribackend.api.v1.credit;
 
 import com.naribackend.api.v1.credit.request.PayCreditRequest;
+import com.naribackend.api.v1.credit.request.PayDailyCounselingRequest;
+import com.naribackend.api.v1.credit.response.PayDailyCounselingResponse;
 import com.naribackend.core.auth.CurrentUser;
 import com.naribackend.core.auth.LoginUser;
 import com.naribackend.core.credit.UserCreditService;
+import com.naribackend.core.talk.TalkInfo;
 import com.naribackend.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +31,18 @@ public class CreditController {
         userCreditService.payCredit(loginUser, request.toPayCreditOperation(), request.toIdempotencyKey());
 
         return ApiResponse.success();
+    }
+
+    @PostMapping("/pay/daily-counseling")
+    public ApiResponse<?> payDailyCounseling(
+            @Parameter(hidden = true)
+            @CurrentUser final LoginUser loginUser,
+            @RequestBody final PayDailyCounselingRequest request
+    ) {
+        TalkInfo talkInfo = userCreditService.payDailyCounseling(loginUser, request.toIdempotencyKey());
+
+        return ApiResponse.success(
+                PayDailyCounselingResponse.from(talkInfo)
+        );
     }
 }

--- a/src/main/java/com/naribackend/api/v1/credit/request/PayDailyCounselingRequest.java
+++ b/src/main/java/com/naribackend/api/v1/credit/request/PayDailyCounselingRequest.java
@@ -1,0 +1,13 @@
+package com.naribackend.api.v1.credit.request;
+
+import com.naribackend.core.idempotency.IdempotencyKey;
+import jakarta.validation.constraints.NotBlank;
+
+public record PayDailyCounselingRequest (
+        @NotBlank(message = "Idempotency 키는 필수입니다.")
+        String idempotencyKey
+){
+    public IdempotencyKey toIdempotencyKey() {
+        return IdempotencyKey.from(idempotencyKey);
+    }
+}

--- a/src/main/java/com/naribackend/api/v1/credit/response/PayDailyCounselingResponse.java
+++ b/src/main/java/com/naribackend/api/v1/credit/response/PayDailyCounselingResponse.java
@@ -1,0 +1,17 @@
+package com.naribackend.api.v1.credit.response;
+
+import com.naribackend.core.talk.TalkInfo;
+import lombok.Builder;
+
+@Builder
+public record PayDailyCounselingResponse (
+        Long paidUserCreditHistoryId,
+        Long talkId
+){
+    public static PayDailyCounselingResponse from(TalkInfo talkInfo) {
+        return PayDailyCounselingResponse.builder()
+                .paidUserCreditHistoryId(talkInfo.getPaidUserCreditHistoryId())
+                .talkId(talkInfo.getTalkId())
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/api/v1/talk/TalkController.java
+++ b/src/main/java/com/naribackend/api/v1/talk/TalkController.java
@@ -2,10 +2,13 @@ package com.naribackend.api.v1.talk;
 
 import com.naribackend.api.v1.talk.request.CreateTalkSessionRequest;
 import com.naribackend.api.v1.talk.response.CreateTalkSessionResponse;
+import com.naribackend.api.v1.talk.response.GetTalkTopActiveInfoResponse;
 import com.naribackend.core.auth.CurrentUser;
 import com.naribackend.core.auth.LoginUser;
+import com.naribackend.core.talk.TalkService;
 import com.naribackend.core.talk.TalkSession;
 import com.naribackend.core.talk.TalkSessionService;
+import com.naribackend.core.talk.TalkTopActiveInfo;
 import com.naribackend.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +20,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/talk")
 public class TalkController {
+
+    private final TalkService talkService;
 
     private final TalkSessionService talkSessionService;
 
@@ -30,13 +35,28 @@ public class TalkController {
             @Valid @RequestBody final CreateTalkSessionRequest request
     ) {
         TalkSession talkSession = talkSessionService.createTalkSession(
-                request.paidUserCreditHistoryId(),
+                request.parentTalkId(),
                 loginUser,
                 request.toIdempotencyKey()
         );
 
         return ApiResponse.success(
                 CreateTalkSessionResponse.from(talkSession)
+        );
+    }
+
+    @Operation(
+            summary = "이용 가능한 Talk 중 하나의 Talk에 대해 상세 정보 조회",
+            description = "사용자가 이용 가능한 Talk를 하나에 대해 조회합니다. 이 API는 사용자가 Talk를 시작하기 전에 호출되어야 합니다."
+    )
+    @GetMapping("/top-active")
+    public ApiResponse<?> getTopActiveTalkInfo(
+            @Parameter(hidden = true) @CurrentUser final LoginUser loginUser
+    ) {
+        TalkTopActiveInfo topActiveTalkInfo = talkService.getTopActiveTalkInfo(loginUser);
+
+        return ApiResponse.success(
+                GetTalkTopActiveInfoResponse.from(topActiveTalkInfo)
         );
     }
 }

--- a/src/main/java/com/naribackend/api/v1/talk/request/CreateTalkSessionRequest.java
+++ b/src/main/java/com/naribackend/api/v1/talk/request/CreateTalkSessionRequest.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 @Builder
 public record CreateTalkSessionRequest(
         @NotNull(message = "지불한 사용자 크레딧 히스토리 ID는 필수입니다.")
-        Long paidUserCreditHistoryId,
+        Long parentTalkId,
 
         @NotBlank(message = "Idempotency 키는 필수입니다.")
         String idempotencyKey

--- a/src/main/java/com/naribackend/api/v1/talk/response/CreateTalkSessionResponse.java
+++ b/src/main/java/com/naribackend/api/v1/talk/response/CreateTalkSessionResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 public record CreateTalkSessionResponse (
         Long talkSessionId,
-        Long paidUserCreditHistoryId,
+        Long parentTalkId,
         Long createdUserId,
         TalkSessionStatus status,
         LocalDateTime createdAt,
@@ -18,7 +18,7 @@ public record CreateTalkSessionResponse (
     public static CreateTalkSessionResponse from(final TalkSession talkSession) {
         return CreateTalkSessionResponse.builder()
                 .talkSessionId(talkSession.getId())
-                .paidUserCreditHistoryId(talkSession.getPaidUserCreditHistoryId())
+                .parentTalkId(talkSession.getParentTalkId())
                 .createdUserId(talkSession.getCreatedUserId())
                 .status(talkSession.getStatus())
                 .createdAt(talkSession.getCreatedAt())

--- a/src/main/java/com/naribackend/api/v1/talk/response/GetTalkInfoResponse.java
+++ b/src/main/java/com/naribackend/api/v1/talk/response/GetTalkInfoResponse.java
@@ -1,0 +1,42 @@
+package com.naribackend.api.v1.talk.response;
+
+import com.naribackend.core.talk.TalkInfo;
+import com.naribackend.core.talk.TalkStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GetTalkInfoResponse {
+
+    private Long talkId;
+
+    private Long createdUserId;
+
+    private Long paidUserCreditHistoryId;
+
+    private TalkStatus status;
+
+    private int createdSessionCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    private LocalDateTime expiredAt;
+
+    public static GetTalkInfoResponse from(TalkInfo talkInfo) {
+        return GetTalkInfoResponse.builder()
+                .talkId(talkInfo.getTalkId())
+                .createdUserId(talkInfo.getCreatedUserId())
+                .paidUserCreditHistoryId(talkInfo.getPaidUserCreditHistoryId())
+                .status(talkInfo.getStatus())
+                .createdSessionCount(talkInfo.getCreatedSessionCount())
+                .createdAt(talkInfo.getCreatedAt())
+                .modifiedAt(talkInfo.getModifiedAt())
+                .expiredAt(talkInfo.getExpiredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/api/v1/talk/response/GetTalkTopActiveInfoResponse.java
+++ b/src/main/java/com/naribackend/api/v1/talk/response/GetTalkTopActiveInfoResponse.java
@@ -1,0 +1,22 @@
+package com.naribackend.api.v1.talk.response;
+
+import com.naribackend.core.talk.TalkInfo;
+import com.naribackend.core.talk.TalkTopActiveInfo;
+import lombok.Builder;
+
+@Builder
+public record GetTalkTopActiveInfoResponse(
+        boolean existsActiveTalk,
+        GetTalkInfoResponse topActiveTalkInfo,
+        int maxSessionCountPerPay
+) {
+    public static GetTalkTopActiveInfoResponse from(final TalkTopActiveInfo talkTopActiveInfo) {
+        TalkInfo topActiveTalkInfo = talkTopActiveInfo.getTopActiveTalkInfo();
+
+        return GetTalkTopActiveInfoResponse.builder()
+                .existsActiveTalk(talkTopActiveInfo.isExistsActiveTalk())
+                .topActiveTalkInfo(GetTalkInfoResponse.from(topActiveTalkInfo))
+                .maxSessionCountPerPay(talkTopActiveInfo.getMaxSessionCountPerPay())
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/api/v1/token/TokenController.java
+++ b/src/main/java/com/naribackend/api/v1/token/TokenController.java
@@ -18,7 +18,8 @@ public class TokenController {
 
     private final TokenService tokenService;
 
-    @PostMapping("/realtime")
+    //@PostMapping("/realtime")
+    // 현재 사용하지 않는 API로 주석 처리
     public ApiResponse<GetRealtimeTokenResponse> createToken(
         @Parameter(hidden = true)
         @CurrentUser final LoginUser loginUser

--- a/src/main/java/com/naribackend/config/SecurityConfig.java
+++ b/src/main/java/com/naribackend/config/SecurityConfig.java
@@ -21,18 +21,7 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
-                            "/api/v1/auth/email-verification-code",
-                            "/api/v1/auth/email-verification-code/check",
-                            "/api/v1/auth/sign-up",
-                            "/api/v1/auth/sign-in/access-token",
-                            "/api/v1/auth/me",
-                            "/api/v1/user/me/withdrawal",
-                            "/api/v1/user/me/password",
-                            "/api/v1/user/me/nickname",
-                            "/api/v1/token/realtime",
-                            "/api/v1/ops/credit/charge",
-                            "/api/v1/credit/pay",
-                            "/api/v1/talk/**"
+                            "/api/v1/**"
                     ).permitAll()
                     .requestMatchers(
                             "/v3/api-docs/**",

--- a/src/main/java/com/naribackend/core/auth/LoginUser.java
+++ b/src/main/java/com/naribackend/core/auth/LoginUser.java
@@ -10,4 +10,10 @@ import lombok.RequiredArgsConstructor;
 public class LoginUser {
 
     private final long id;
+
+    public static LoginUser from(final long userId) {
+        return LoginUser.builder()
+                .id(userId)
+                .build();
+    }
 }

--- a/src/main/java/com/naribackend/core/credit/UserCreditHistoryAppender.java
+++ b/src/main/java/com/naribackend/core/credit/UserCreditHistoryAppender.java
@@ -3,6 +3,7 @@ package com.naribackend.core.credit;
 import com.naribackend.core.common.CreditOperationReason;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -10,7 +11,8 @@ public class UserCreditHistoryAppender {
 
     private final UserCreditHistoryRepository userCreditHistoryRepository;
 
-    public void append(
+    @Transactional
+    public UserCreditHistory append(
             final Long createdUserId,
             final CreditOperationReason reason,
             final long changedCreditAmount,
@@ -23,6 +25,6 @@ public class UserCreditHistoryAppender {
                 currentCredit
         );
 
-        userCreditHistoryRepository.save(userCreditHistory);
+        return userCreditHistoryRepository.save(userCreditHistory);
     }
 }

--- a/src/main/java/com/naribackend/core/credit/UserCreditModifier.java
+++ b/src/main/java/com/naribackend/core/credit/UserCreditModifier.java
@@ -2,12 +2,7 @@ package com.naribackend.core.credit;
 
 import com.naribackend.support.error.CoreException;
 import com.naribackend.support.error.ErrorType;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.StaleObjectStateException;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,12 +12,6 @@ public class UserCreditModifier {
 
     private final UserCreditRepository userCreditRepository;
 
-    @Retryable(
-            retryFor = {OptimisticLockException.class, DataIntegrityViolationException.class,
-                        StaleObjectStateException.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 500, multiplier = 1.5, maxDelay = 1000)
-    )
     @Transactional
     public Credit payCredit(final long targetUserId, final PayCreditOperation operation) {
 

--- a/src/main/java/com/naribackend/core/credit/UserCreditService.java
+++ b/src/main/java/com/naribackend/core/credit/UserCreditService.java
@@ -3,8 +3,17 @@ package com.naribackend.core.credit;
 import com.naribackend.core.idempotency.IdempotencyAppender;
 import com.naribackend.core.idempotency.IdempotencyKey;
 import com.naribackend.core.auth.LoginUser;
+import com.naribackend.core.talk.Talk;
+import com.naribackend.core.talk.TalkAppender;
+import com.naribackend.core.talk.TalkInfo;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.StaleObjectStateException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +25,15 @@ public class UserCreditService {
 
     private final IdempotencyAppender idempotencyAppender;
 
+    private final TalkAppender talkAppender;
+
+    @Retryable(
+            retryFor = {OptimisticLockException.class, DataIntegrityViolationException.class,
+                    StaleObjectStateException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500, multiplier = 1.5, maxDelay = 1000)
+    )
+    @Transactional
     public void payCredit(
             final LoginUser loginUser,
             final PayCreditOperation payOperation,
@@ -34,5 +52,29 @@ public class UserCreditService {
                 -payOperation.getCreditAmountToPay(),
                 currentCredit
         );
+    }
+
+    @Transactional
+    public TalkInfo payDailyCounseling(
+            LoginUser loginUser,
+            IdempotencyKey idempotencyKey
+    ) {
+        idempotencyAppender.appendOrThrowIfExists(idempotencyKey);
+        PayCreditOperation dailyCounselingOp = PayCreditOperation.DAILY_COUNSELING;
+
+        Credit currentCredit = userCreditModifier.payCredit(
+                loginUser.getId(),
+                PayCreditOperation.DAILY_COUNSELING
+        );
+
+        UserCreditHistory userCreditHistory = userCreditHistoryAppender.append(
+                loginUser.getId(),
+                dailyCounselingOp.toReason(),
+                -dailyCounselingOp.getCreditAmountToPay(),
+                currentCredit
+        );
+
+        Talk savedTalk = talkAppender.append(userCreditHistory);
+       return TalkInfo.from(savedTalk, 0);
     }
 }

--- a/src/main/java/com/naribackend/core/talk/Talk.java
+++ b/src/main/java/com/naribackend/core/talk/Talk.java
@@ -1,0 +1,26 @@
+package com.naribackend.core.talk;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class Talk {
+
+    private Long id;
+
+    private Long createdUserId;
+
+    private Long paidUserCreditHistoryId;
+
+    private TalkStatus status;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    private LocalDateTime expiredAt;
+
+}

--- a/src/main/java/com/naribackend/core/talk/Talk.java
+++ b/src/main/java/com/naribackend/core/talk/Talk.java
@@ -1,5 +1,6 @@
 package com.naribackend.core.talk;
 
+import com.naribackend.core.auth.LoginUser;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,4 +24,16 @@ public class Talk {
 
     private LocalDateTime expiredAt;
 
+    boolean isUserCreated(final LoginUser loginUser) {
+        return this.createdUserId.equals(loginUser.getId());
+    }
+
+    public boolean isCreatedAtBefore(final LocalDateTime minimumValidDateTime) {
+        return this.createdAt.isBefore(minimumValidDateTime);
+    }
+
+    public void complete(final LocalDateTime currentTime) {
+        this.status = TalkStatus.COMPLETED;
+        this.modifiedAt = currentTime;
+    }
 }

--- a/src/main/java/com/naribackend/core/talk/TalkAppender.java
+++ b/src/main/java/com/naribackend/core/talk/TalkAppender.java
@@ -1,0 +1,41 @@
+package com.naribackend.core.talk;
+
+import com.naribackend.core.DateTimeProvider;
+import com.naribackend.core.credit.UserCreditHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class TalkAppender {
+
+    private final TalkRepository talkRepository;
+
+    private final TalkPolicyProperties talkPolicyProperties;
+
+    private final DateTimeProvider dateTimeProvider;
+
+    @Transactional
+    public Talk append(
+            final UserCreditHistory paidUserCreditHistory
+    ) {
+        LocalDateTime currentDateTime = dateTimeProvider.getCurrentDateTime();
+
+        LocalDateTime expiredAt = currentDateTime
+                .plusMinutes(talkPolicyProperties.getMaxSessionDurationInMinutes());
+
+        Talk talk = Talk.builder()
+                .createdUserId(paidUserCreditHistory.getCreatedUserId())
+                .paidUserCreditHistoryId(paidUserCreditHistory.getId())
+                .status(TalkStatus.CREATED)
+                .createdAt(currentDateTime)
+                .modifiedAt(currentDateTime)
+                .expiredAt(expiredAt)
+                .build();
+
+        return talkRepository.save(talk);
+    }
+}

--- a/src/main/java/com/naribackend/core/talk/TalkInfo.java
+++ b/src/main/java/com/naribackend/core/talk/TalkInfo.java
@@ -1,0 +1,40 @@
+package com.naribackend.core.talk;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TalkInfo {
+
+    private Long talkId;
+
+    private Long createdUserId;
+
+    private Long paidUserCreditHistoryId;
+
+    private TalkStatus status;
+
+    private int createdSessionCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    private LocalDateTime expiredAt;
+
+    public static TalkInfo from(Talk talk, int createdSessionCount) {
+        return TalkInfo.builder()
+                .talkId(talk.getId())
+                .createdUserId(talk.getCreatedUserId())
+                .paidUserCreditHistoryId(talk.getPaidUserCreditHistoryId())
+                .status(talk.getStatus())
+                .createdSessionCount(createdSessionCount)
+                .createdAt(talk.getCreatedAt())
+                .modifiedAt(talk.getModifiedAt())
+                .expiredAt(talk.getExpiredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/core/talk/TalkRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkRepository.java
@@ -1,6 +1,25 @@
 package com.naribackend.core.talk;
 
+import com.naribackend.core.auth.LoginUser;
+
+import java.util.Optional;
+
 public interface TalkRepository {
 
     Talk save(Talk talk);
+
+    /*
+    *
+    * 다음 조건을 만족해야 함
+    * 1. Talk가 COMPLETED 상태가 아니여야 함
+    * 2. Talk의 참여자가 로그인한 사용자여야 함
+    * 3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
+    * 4. Talk의 갯수은 1개여야 함
+    * 5. max-session-count-per-pay 값이 Talk의 sessionCount보다 작아야함
+    *
+    * */
+    Optional<Talk> findNotCompletedTopTalkById(LoginUser loginUser, long maxSessionCountPerPay);
+
+    Optional<Talk> findById(Long talkId);
+
 }

--- a/src/main/java/com/naribackend/core/talk/TalkRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkRepository.java
@@ -1,0 +1,6 @@
+package com.naribackend.core.talk;
+
+public interface TalkRepository {
+
+    Talk save(Talk talk);
+}

--- a/src/main/java/com/naribackend/core/talk/TalkService.java
+++ b/src/main/java/com/naribackend/core/talk/TalkService.java
@@ -1,0 +1,26 @@
+package com.naribackend.core.talk;
+
+import com.naribackend.core.auth.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TalkService {
+
+    private final TalkPolicyProperties talkPolicyProperties;
+
+    private final TalkRepository talkRepository;
+
+    private final TalkSessionRepository talkSessionRepository;
+
+    public TalkTopActiveInfo getTopActiveTalkInfo(final LoginUser loginUser) {
+
+        int maxSessionCountPerPay = talkPolicyProperties.getMaxSessionCountPerPay();
+
+        return talkRepository.findNotCompletedTopTalkById(loginUser, maxSessionCountPerPay)
+                .map(talk -> TalkInfo.from(talk, talkSessionRepository.countBy(talk)))
+                .map(talkInfo -> TalkTopActiveInfo.from(talkInfo, maxSessionCountPerPay))
+                .orElseGet(TalkTopActiveInfo::empty);
+    }
+}

--- a/src/main/java/com/naribackend/core/talk/TalkSession.java
+++ b/src/main/java/com/naribackend/core/talk/TalkSession.java
@@ -1,6 +1,5 @@
 package com.naribackend.core.talk;
 
-import com.naribackend.core.credit.UserCreditHistory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +11,7 @@ public class TalkSession {
 
     private Long id;
 
-    private final Long paidUserCreditHistoryId;
+    private final Long parentTalkId;
 
     private final Long createdUserId;
 
@@ -22,10 +21,10 @@ public class TalkSession {
 
     private LocalDateTime completedAt;
 
-    public static TalkSession from(final UserCreditHistory userCreditHistory) {
+    public static TalkSession from(final Talk parentTalk) {
         return TalkSession.builder()
-                .paidUserCreditHistoryId(userCreditHistory.getId())
-                .createdUserId(userCreditHistory.getCreatedUserId())
+                .parentTalkId(parentTalk.getId())
+                .createdUserId(parentTalk.getCreatedUserId())
                 .status(TalkSessionStatus.CREATED)
                 .build();
     }

--- a/src/main/java/com/naribackend/core/talk/TalkSessionRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkSessionRepository.java
@@ -1,8 +1,5 @@
 package com.naribackend.core.talk;
 
-
-import com.naribackend.core.credit.UserCreditHistory;
-
 public interface TalkSessionRepository {
 
     int countBy(Talk parentTalk);

--- a/src/main/java/com/naribackend/core/talk/TalkSessionRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkSessionRepository.java
@@ -5,9 +5,9 @@ import com.naribackend.core.credit.UserCreditHistory;
 
 public interface TalkSessionRepository {
 
-    int countBy(UserCreditHistory payedUserCreditHistory);
+    int countBy(Talk parentTalk);
 
-    boolean existsCompletedSessionBy(UserCreditHistory paidUserCreditHistory);
+    boolean existsCompletedSessionBy(Talk talk);
 
-    TalkSession save(TalkSession from);
+    TalkSession save(TalkSession talkSession);
 }

--- a/src/main/java/com/naribackend/core/talk/TalkStatus.java
+++ b/src/main/java/com/naribackend/core/talk/TalkStatus.java
@@ -1,0 +1,17 @@
+package com.naribackend.core.talk;
+
+public enum TalkStatus {
+
+    CREATED,
+    IN_PROGRESS,
+    COMPLETED,
+    CANCELLED;
+
+    public boolean isCompleted() {
+        return this == COMPLETED;
+    }
+
+    public boolean isNotFinalized() {
+        return this == CREATED || this == IN_PROGRESS;
+    }
+}

--- a/src/main/java/com/naribackend/core/talk/TalkTopActiveInfo.java
+++ b/src/main/java/com/naribackend/core/talk/TalkTopActiveInfo.java
@@ -1,0 +1,31 @@
+package com.naribackend.core.talk;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TalkTopActiveInfo {
+
+    private boolean existsActiveTalk;
+
+    private TalkInfo topActiveTalkInfo;
+
+    private int maxSessionCountPerPay;
+
+    public static TalkTopActiveInfo from(TalkInfo topActiveTalkInfo, int maxSessionCountPerPay) {
+        return TalkTopActiveInfo.builder()
+                .existsActiveTalk(topActiveTalkInfo != null)
+                .topActiveTalkInfo(topActiveTalkInfo)
+                .maxSessionCountPerPay(maxSessionCountPerPay)
+                .build();
+    }
+
+    public static TalkTopActiveInfo empty() {
+        return TalkTopActiveInfo.builder()
+                .existsActiveTalk(false)
+                .topActiveTalkInfo(null)
+                .maxSessionCountPerPay(0)
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/storage/credit/UserCreditEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/credit/UserCreditEntityRepository.java
@@ -4,6 +4,7 @@ import com.naribackend.core.credit.UserCredit;
 import com.naribackend.core.credit.UserCreditRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -20,6 +21,7 @@ public class UserCreditEntityRepository implements UserCreditRepository {
     }
 
     @Override
+    @Transactional
     public void save(UserCredit userCredit) {
         UserCreditEntity userCreditEntity = UserCreditEntity.from(userCredit);
         userCreditJpaRepository.save(userCreditEntity);

--- a/src/main/java/com/naribackend/storage/talk/TalkEntity.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkEntity.java
@@ -1,0 +1,57 @@
+package com.naribackend.storage.talk;
+
+import com.naribackend.core.talk.Talk;
+import com.naribackend.core.talk.TalkStatus;
+import com.naribackend.storage.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@Table(name = "talk")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class TalkEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "created_user_id", nullable = false)
+    private Long createdUserId;
+
+    @Column(name = "paid_user_credit_history_id", nullable = false)
+    private Long paidUserCreditHistoryId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private TalkStatus status;
+
+    private LocalDateTime expiredAt;
+
+    public static TalkEntity from(final Talk talk) {
+        return TalkEntity.builder()
+                .id(talk.getId())
+                .createdUserId(talk.getCreatedUserId())
+                .paidUserCreditHistoryId(talk.getPaidUserCreditHistoryId())
+                .status(talk.getStatus())
+                .expiredAt(talk.getExpiredAt())
+                .build();
+    }
+
+    public Talk toTalk() {
+        return Talk.builder()
+                .id(this.id)
+                .createdUserId(this.createdUserId)
+                .paidUserCreditHistoryId(this.paidUserCreditHistoryId)
+                .status(this.status)
+                .createdAt(this.getCreatedAt())
+                .modifiedAt(this.getModifiedAt())
+                .expiredAt(this.expiredAt)
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/storage/talk/TalkEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkEntityRepository.java
@@ -1,9 +1,13 @@
 package com.naribackend.storage.talk;
 
+import com.naribackend.core.auth.LoginUser;
 import com.naribackend.core.talk.Talk;
 import com.naribackend.core.talk.TalkRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,5 +20,23 @@ public class TalkEntityRepository implements TalkRepository {
         TalkEntity savedEntity = talkJpaRepository.save(TalkEntity.from(talk));
 
         return savedEntity.toTalk();
+    }
+
+    @Override
+    public Optional<Talk> findNotCompletedTopTalkById(
+            final LoginUser loginUser,
+            final long maxSessionCountPerPay
+    ) {
+        return talkJpaRepository.findCandidateTalk(
+                loginUser.getId(),
+                maxSessionCountPerPay,
+                Pageable.ofSize(1)
+        ).stream().findFirst().map(TalkEntity::toTalk);
+    }
+
+    @Override
+    public Optional<Talk> findById(Long talkId) {
+        return talkJpaRepository.findById(talkId)
+                .map(TalkEntity::toTalk);
     }
 }

--- a/src/main/java/com/naribackend/storage/talk/TalkEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkEntityRepository.java
@@ -1,0 +1,20 @@
+package com.naribackend.storage.talk;
+
+import com.naribackend.core.talk.Talk;
+import com.naribackend.core.talk.TalkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TalkEntityRepository implements TalkRepository {
+
+    private final TalkJpaRepository talkJpaRepository;
+
+    @Override
+    public Talk save(Talk talk) {
+        TalkEntity savedEntity = talkJpaRepository.save(TalkEntity.from(talk));
+
+        return savedEntity.toTalk();
+    }
+}

--- a/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
@@ -1,6 +1,40 @@
 package com.naribackend.storage.talk;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TalkJpaRepository extends JpaRepository<TalkEntity, Long> {
+
+    /**
+     * 다음 조건을 만족해야 함
+     * 1. Talk가 COMPLETED 상태가 아니여야 함
+     * 2. Talk의 참여자가 userId여야 함
+     * 3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
+     * 4. max-session-count-per-pay 값이 Talk의 sessionCount보다 작아야함
+     *
+     * @param userId                참여자 ID
+     * @param maxSessionCountPerPay 최대 세션 수
+     * @return 조건을 만족하는 Talk 엔티티
+     */
+    @Query("""
+        select t
+        from TalkEntity t
+        where t.status <> com.naribackend.core.talk.TalkStatus.COMPLETED
+        and t.createdUserId = :userId
+        and (select count(s)
+            from TalkSessionEntity s
+            where s.parentTalkId = t.id) < :maxSessionCountPerPay
+        order by (select count(s2)
+              from TalkSessionEntity s2
+              where s2.parentTalkId = t.id) desc,
+             t.expiredAt asc
+    """)
+    Page<TalkEntity> findCandidateTalk(
+            @Param("userId") Long userId,
+            @Param("maxSessionCountPerPay") long maxSessionCountPerPay,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
@@ -1,0 +1,6 @@
+package com.naribackend.storage.talk;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TalkJpaRepository extends JpaRepository<TalkEntity, Long> {
+}

--- a/src/main/java/com/naribackend/storage/talk/TalkSessionEntity.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkSessionEntity.java
@@ -22,8 +22,8 @@ public class TalkSessionEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "paid_user_credit_history_id", nullable = false)
-    private Long paidUserCreditHistoryId;
+    @Column(name = "parent_talk_id", nullable = false)
+    private Long parentTalkId;
 
     @Column(name = "created_user_id", nullable = false)
     private Long createdUserId;
@@ -38,7 +38,7 @@ public class TalkSessionEntity extends BaseEntity {
     public static TalkSessionEntity from(final TalkSession talkSession) {
         return TalkSessionEntity.builder()
                 .id(talkSession.getId())
-                .paidUserCreditHistoryId(talkSession.getPaidUserCreditHistoryId())
+                .parentTalkId(talkSession.getParentTalkId())
                 .createdUserId(talkSession.getCreatedUserId())
                 .status(talkSession.getStatus())
                 .completedAt(talkSession.getCompletedAt())
@@ -48,7 +48,7 @@ public class TalkSessionEntity extends BaseEntity {
     public TalkSession toTalkSession() {
         return TalkSession.builder()
                 .id(this.id)
-                .paidUserCreditHistoryId(this.paidUserCreditHistoryId)
+                .parentTalkId(this.parentTalkId)
                 .createdUserId(this.createdUserId)
                 .status(this.status)
                 .createdAt(this.getCreatedAt())

--- a/src/main/java/com/naribackend/storage/talk/TalkSessionEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkSessionEntityRepository.java
@@ -1,6 +1,6 @@
 package com.naribackend.storage.talk;
 
-import com.naribackend.core.credit.UserCreditHistory;
+import com.naribackend.core.talk.Talk;
 import com.naribackend.core.talk.TalkSession;
 import com.naribackend.core.talk.TalkSessionRepository;
 import com.naribackend.core.talk.TalkSessionStatus;
@@ -14,17 +14,17 @@ public class TalkSessionEntityRepository implements TalkSessionRepository {
     private final TalkSessionJpaRepository talkSessionJpaRepository;
 
     @Override
-    public int countBy(final UserCreditHistory payedUserCreditHistory) {
-        return talkSessionJpaRepository.countByPaidUserCreditHistoryId(
-                payedUserCreditHistory.getId()
+    public int countBy(final Talk parentTalk) {
+        return talkSessionJpaRepository.countByParentTalkId(
+                parentTalk.getId()
         );
     }
 
     @Override
-    public boolean existsCompletedSessionBy(final UserCreditHistory paidUserCreditHistory) {
-        return talkSessionJpaRepository.existsByStatusAndPaidUserCreditHistoryId(
+    public boolean existsCompletedSessionBy(final Talk talk) {
+        return talkSessionJpaRepository.existsByStatusAndParentTalkId(
                 TalkSessionStatus.COMPLETED,
-                paidUserCreditHistory.getId()
+                talk.getId()
         );
     }
 

--- a/src/main/java/com/naribackend/storage/talk/TalkSessionJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkSessionJpaRepository.java
@@ -5,7 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TalkSessionJpaRepository extends JpaRepository<TalkSessionEntity, Long> {
 
-    int countByPaidUserCreditHistoryId(Long paidUserCreditHistoryId);
+    int countByParentTalkId(Long talkId);
 
-    boolean existsByStatusAndPaidUserCreditHistoryId(TalkSessionStatus status, Long paidUserCreditHistoryId);
+    boolean existsByStatusAndParentTalkId(TalkSessionStatus status, Long talkId);
+
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -35,16 +35,16 @@ public enum ErrorType {
     INVALID_CREDIT_OPERATION_REASON(HttpStatus.BAD_REQUEST, ErrorCode.E500, "잘못된 크레딧 연산 사유입니다.", LogLevel.DEBUG),
     INVALID_IDEMPOTENCY_KEY(HttpStatus.BAD_REQUEST, ErrorCode.E400, "중복된 요청 입니다.", LogLevel.DEBUG),
 
-    INVALID_USER_REQUEST_USER_CREDIT_HISTORY (
+    INVALID_USER_REQUEST_TALK_SESSION(
             HttpStatus.FORBIDDEN,
             ErrorCode.E403,
-            "해당 크레딧 이력에 접근할 수 없습니다.",
+            "해당 대화 세션에 접근할 수 없습니다.",
             LogLevel.INFO
     ),
-    NOT_FOUND_USER_CREDIT_HISTORY (
+    NOT_FOUND_TALK(
             HttpStatus.NOT_FOUND,
             ErrorCode.E404,
-            "결제(크레딧) 이력을 찾을 수 없습니다.",
+            "해당 대화를 찾을 수 없습니다.",
             LogLevel.INFO
     ),
     TALK_SESSION_RETRY_LIMIT_EXCEEDED (
@@ -59,10 +59,10 @@ public enum ErrorType {
             "대화 세션이 최대 지속 시간을 초과했습니다.",
             LogLevel.INFO
     ),
-    EXPIRED_USER_CREDIT_HISTORY (
+    EXPIRED_TALK(
             HttpStatus.CONFLICT,
             ErrorCode.E409,
-            "해당 크레딧 이력은 만료되었습니다.",
+            "해당 대화는 만료되었습니다.",
             LogLevel.INFO
     ),
     TALK_SESSION_NOT_STARTED (

--- a/src/test/java/com/naribackend/credit/CreditIntegrationTest.java
+++ b/src/test/java/com/naribackend/credit/CreditIntegrationTest.java
@@ -1,14 +1,21 @@
 package com.naribackend.credit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
 import com.naribackend.api.v1.credit.request.PayCreditRequest;
+import com.naribackend.api.v1.credit.request.PayDailyCounselingRequest;
 import com.naribackend.core.credit.UserCreditRepository;
 import com.naribackend.core.idempotency.IdempotencyKey;
 import com.naribackend.core.idempotency.IdempotencyRepository;
+import com.naribackend.core.talk.TalkAppender;
+import com.naribackend.storage.credit.UserCreditHistoryJpaRepository;
+import com.naribackend.storage.talk.TalkEntityRepository;
+import com.naribackend.storage.talk.TalkJpaRepository;
 import com.naribackend.support.TestUser;
 import com.naribackend.support.TestUserFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +24,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -27,10 +36,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("test")
 @Transactional
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class CreditIntegrationTest {
@@ -49,6 +60,15 @@ public class CreditIntegrationTest {
 
     @Autowired
     UserCreditRepository userCreditRepository;
+
+    @MockitoSpyBean
+    TalkAppender talkAppender;
+
+    @Autowired
+    UserCreditHistoryJpaRepository userCreditHistoryJpaRepository;
+
+    @Autowired
+    private TalkJpaRepository talkJpaRepository;
 
     private static final long DAILY_COUNSELING_CREDIT_PER_REQUEST = 1000L;
 
@@ -159,6 +179,7 @@ public class CreditIntegrationTest {
     @RepeatedTest(5)
     @DisplayName("사용자 크레딧 결제 테스트 성공 - 동시 요청 처리")
     void pay_credit_concurrent_requests() throws Exception {
+
         // given
         long userCreditAmount = 10000L;
         TestUser testUser = testUserFactory.createTestUserWithCredit(userCreditAmount);
@@ -221,5 +242,76 @@ public class CreditIntegrationTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("일일 상담 결제 API 실패 - 의도적인 Talk 생성 실패")
+    void pay_credit_fail_intentional_talk_creation_failure() throws Exception {
+        // given
+        long expectedCreditAmount = DAILY_COUNSELING_CREDIT_PER_REQUEST;
+        TestUser testUser = testUserFactory.createTestUserWithCredit(expectedCreditAmount);
+        String accessToken = testUser.accessToken();
+        PayDailyCounselingRequest request = new PayDailyCounselingRequest(
+                IDEMPOTENCY_KEY
+        );
+
+        doThrow(new RuntimeException("fail"))
+                .when(talkAppender)
+                .append(any());
+
+        // when & then
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/credit/pay/daily-counseling")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().is5xxServerError());
+
+        // then
+        assertThat(idempotencyRepository.exists(IdempotencyKey.from(IDEMPOTENCY_KEY))).isFalse();
+
+        // 최종 크레딧 금액은 변경되지 않아야 함
+        long actualUserCreditAmount = userCreditRepository.getUserCredit(testUser.id())
+                .orElseThrow()
+                .getCredit()
+                .creditAmount();
+        assertThat(actualUserCreditAmount).isEqualTo(expectedCreditAmount);
+    }
+
+    @Test
+    @DisplayName("일일 상담 결제 API 성공")
+    void pay_daily_counseling_success() throws Exception {
+        // given
+        TestUser testUser = testUserFactory.createTestUserWithCredit(DAILY_COUNSELING_CREDIT_PER_REQUEST);
+        long expectedCreditAmount = 0L;
+        String accessToken = testUser.accessToken();
+        PayDailyCounselingRequest request = new PayDailyCounselingRequest(
+                IDEMPOTENCY_KEY
+        );
+
+        // when & then
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/credit/pay/daily-counseling")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    String jsonResponse = result.getResponse().getContentAsString();
+                    Long talkId = JsonPath.parse(jsonResponse).read("$.data.talkId", Long.class);
+                    assertThat(talkJpaRepository.existsById(talkId)).isTrue();
+
+                    Long paidUserCreditHistoryId = JsonPath.parse(jsonResponse).read("$.data.paidUserCreditHistoryId", Long.class);
+                    assertThat(userCreditHistoryJpaRepository.existsById(paidUserCreditHistoryId)).isTrue();
+                });
+
+        // then
+        assertThat(idempotencyRepository.exists(IdempotencyKey.from(IDEMPOTENCY_KEY))).isTrue();
+
+        long actualUserCreditAmount = userCreditRepository.getUserCredit(testUser.id())
+                .orElseThrow()
+                .getCredit()
+                .creditAmount();
+
+        assertThat(actualUserCreditAmount).isEqualTo(expectedCreditAmount);
     }
 }

--- a/src/test/java/com/naribackend/talk/TalkFactory.java
+++ b/src/test/java/com/naribackend/talk/TalkFactory.java
@@ -1,0 +1,82 @@
+package com.naribackend.talk;
+
+import com.naribackend.core.DateTimeProvider;
+import com.naribackend.core.common.CreditOperationReason;
+import com.naribackend.core.credit.Credit;
+import com.naribackend.core.credit.UserCreditHistory;
+import com.naribackend.core.credit.UserCreditHistoryRepository;
+import com.naribackend.core.talk.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class TalkFactory {
+
+    private final TalkRepository talkRepository;
+
+    private final DateTimeProvider dateTimeProvider;
+
+    private final UserCreditHistoryRepository userCreditHistoryRepository;
+
+    private final TalkSessionRepository talkSessionRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Talk createTalk (
+            final long createdUserId
+    ) {
+        var userCreditHistory = UserCreditHistory.builder()
+                .createdUserId(createdUserId)
+                .reason(CreditOperationReason.DAILY_COUNSELING)
+                .changedCreditAmount(-1000L)
+                .currentCredit(Credit.from(10000L))
+                .build();
+
+        var savedPaidUserCreditHistory = userCreditHistoryRepository.save(userCreditHistory);
+
+        Talk talk = Talk.builder()
+                .createdUserId(createdUserId)
+                .paidUserCreditHistoryId(savedPaidUserCreditHistory.getId())
+                .status(TalkStatus.CREATED)
+                .expiredAt(dateTimeProvider.getCurrentDateTime()
+                        .plusMinutes(30))
+                .build();
+
+        return talkRepository.save(talk);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Talk createTalkWithSession (
+            final long createdUserId,
+            final int childTalkSessionNum,
+            final int expiredTimeIntervalInMinutes,
+            final TalkStatus talkStatus
+    ) {
+        var userCreditHistory = UserCreditHistory.builder()
+                .createdUserId(createdUserId)
+                .reason(CreditOperationReason.DAILY_COUNSELING)
+                .changedCreditAmount(-1000L)
+                .currentCredit(Credit.from(10000L))
+                .build();
+
+        var savedPaidUserCreditHistory = userCreditHistoryRepository.save(userCreditHistory);
+
+        Talk talk = Talk.builder()
+                .createdUserId(createdUserId)
+                .paidUserCreditHistoryId(savedPaidUserCreditHistory.getId())
+                .status(talkStatus)
+                .expiredAt(dateTimeProvider.getCurrentDateTime()
+                        .plusMinutes(expiredTimeIntervalInMinutes))
+                .build();
+
+        Talk savedParentTalk = talkRepository.save(talk);
+
+        for (int i = 0; i < childTalkSessionNum; i++) {
+            talkSessionRepository.save(TalkSession.from(savedParentTalk));
+        }
+
+        return savedParentTalk;
+    }
+}

--- a/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
+++ b/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
@@ -1,0 +1,213 @@
+package com.naribackend.talk;
+
+import com.jayway.jsonpath.JsonPath;
+import com.naribackend.core.auth.LoginUser;
+import com.naribackend.core.idempotency.IdempotencyKey;
+import com.naribackend.core.talk.*;
+import com.naribackend.support.TestUser;
+import com.naribackend.support.TestUserFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TalkIntegrationTest {
+
+    @Autowired
+    private TalkFactory talkFactory;
+
+    @Autowired
+    private TestUserFactory testUserFactory;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TalkService talkService;
+
+    @Autowired
+    private TalkSessionService talkSessionService;
+
+    @Autowired
+    private TalkPolicyProperties talkPolicyProperties;
+
+    private static final String TOP_ACTIVE_TALK_API_PATH = "/api/v1/talk/top-active";
+
+    private static final String IDEMPOTENCY_KEY = "top-active-talk";
+
+    @Test
+    @DisplayName("top active talk 조회 API 성공")
+    void get_top_active_talk_api_success() throws Exception {
+
+        // given
+        TestUser testUser = testUserFactory.createTestUser();
+        Talk expectedParentTalk = talkFactory.createTalk(
+                testUser.id()
+        );
+
+        // when
+        mockMvc.perform(
+                get(TOP_ACTIVE_TALK_API_PATH)
+                .header("Authorization", "Bearer " + testUser.accessToken())
+        ).andExpect(status().isOk())
+        .andExpect(
+            result -> {
+                String jsonResponse = result.getResponse().getContentAsString();
+                var existsActiveTalk = JsonPath.parse(jsonResponse).read("$.data.existsActiveTalk", boolean.class);
+                var topActiveTalkInfoTalkId = JsonPath.parse(jsonResponse).read("$.data.topActiveTalkInfo.talkId", Long.class);
+
+                assertThat(existsActiveTalk).isTrue();
+                assertThat(topActiveTalkInfoTalkId).isEqualTo(expectedParentTalk.getId());
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("top active talk 조회 성공")
+    void get_top_active_talk_service_success() {
+        // given
+        TestUser testUser = testUserFactory.createTestUser();
+        Talk expectedParentTalk = talkFactory.createTalk(
+                testUser.id()
+        );
+
+        // when
+        var topActiveTalkInfo = talkService.getTopActiveTalkInfo(testUser.toLoginUser());
+
+        // then
+        assertThat(topActiveTalkInfo.isExistsActiveTalk()).isTrue();
+        assertThat(topActiveTalkInfo.getTopActiveTalkInfo().getTalkId()).isEqualTo(expectedParentTalk.getId());
+    }
+
+    @Test
+    @DisplayName("top active talk 조회 성공 - 완료된 Talk가 있는 경우")
+    void get_top_active_talk_service_success_completed_talk() {
+        // given
+        TestUser testUser = testUserFactory.createTestUser();
+        Talk expectedParentTalk = talkFactory.createTalk(
+                testUser.id()
+        );
+
+        for(int i=0; i < talkPolicyProperties.getMaxSessionCountPerPay(); i++) {
+            talkSessionService.createTalkSession(
+                    expectedParentTalk.getId(),
+                    testUser.toLoginUser(),
+                    IdempotencyKey.from(IDEMPOTENCY_KEY + i)
+            );
+        }
+
+        // when
+        var topActiveTalkInfo = talkService.getTopActiveTalkInfo(testUser.toLoginUser());
+
+        // then
+        assertThat(topActiveTalkInfo.isExistsActiveTalk()).isFalse();
+    }
+
+    @RepeatedTest(5)
+    @DisplayName("top active talk 조회 성공 - 조회 조건 검사")
+    void get_top_active_talk_service_success_check_sort_condition() {
+        // given
+        int userCount = 10;
+        int sessionsPerUser  = 100;
+        int maxSessionCountPerPay = talkPolicyProperties.getMaxSessionCountPerPay();
+        var talkStatus = List.of(
+                TalkStatus.CREATED,
+                TalkStatus.IN_PROGRESS,
+                TalkStatus.COMPLETED
+        );
+
+        List<TalkInfo> talkInfos =
+                Stream.generate(testUserFactory::createTestUser)
+                        .limit(userCount)
+                        .flatMap(
+                        user -> IntStream.rangeClosed(1, sessionsPerUser)
+                                        .mapToObj(childNum -> {
+                                            int expiredTimeIntervalInMinutes = (int) (Math.random() * 100);
+                                            int talkStatusIndex =  childNum % talkStatus.size();
+                                            TalkStatus parentTalkStatus = talkStatus.get(talkStatusIndex);
+                                            int childTalkSessionNum = 2;
+                                            Talk talk = talkFactory.createTalkWithSession(
+                                                    user.id(),
+                                                    childTalkSessionNum,
+                                                    expiredTimeIntervalInMinutes,
+                                                    parentTalkStatus
+                                            );
+
+                                            return TalkInfo.from(talk, childTalkSessionNum);
+                                        })
+                        ).toList();
+
+        Long expectedUserId = talkInfos.get(talkInfos.size() - 1).getCreatedUserId();
+        LoginUser expectedUser = LoginUser.from(expectedUserId);
+
+        /*
+          다음 조건을 만족해야 함
+          1. Talk가 COMPLETED 상태가 아니여야 함
+          2. Talk의 참여자가 expectedUserId 함
+          3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
+          4. max-session-count-per-pay 값이 Talk의 sessionCount보다 작아야함
+         */
+        var expectedTopActiveTalkInfos = talkInfos.stream()
+                .filter(talkInfo -> talkInfo.getCreatedSessionCount() < maxSessionCountPerPay)
+                .filter(talkInfo -> !talkInfo.getStatus().isCompleted())
+                .filter(talkInfo -> talkInfo.getCreatedUserId().equals(expectedUserId))
+                .sorted(Comparator.comparing(TalkInfo::getCreatedSessionCount, Comparator.reverseOrder())
+                        .thenComparing(TalkInfo::getExpiredAt))
+                .toList();
+
+        var expectedTopActiveTalkInfo = expectedTopActiveTalkInfos.get(0);
+
+
+        // when
+        var topActiveTalkInfo = talkService.getTopActiveTalkInfo(expectedUser);
+
+        // then
+        assertThat(topActiveTalkInfo.isExistsActiveTalk()).isTrue();
+        assertThat(topActiveTalkInfo.getTopActiveTalkInfo().getTalkId()).isEqualTo(expectedTopActiveTalkInfo.getTalkId());
+    }
+
+    @Test
+    @DisplayName("top active talk 조회 실패 - 존재하지 않는 사용자")
+    void get_top_active_talk_service_fail_not_exists_user() {
+        // given
+        LoginUser notExistsUser = LoginUser.from(999L);
+
+        // when
+        var topActiveTalkInfo = talkService.getTopActiveTalkInfo(notExistsUser);
+
+        // then
+        assertThat(topActiveTalkInfo.isExistsActiveTalk()).isFalse();
+    }
+
+    @Test
+    @DisplayName("top active talk 조회 성공 - Talk가 하나도 없는 경우")
+    void get_top_active_talk_service_success_no_talk() {
+        // given
+        TestUser testUser = testUserFactory.createTestUser();
+
+        // when
+        var topActiveTalkInfo = talkService.getTopActiveTalkInfo(testUser.toLoginUser());
+
+        // then
+        assertThat(topActiveTalkInfo.isExistsActiveTalk()).isFalse();
+    }
+
+}

--- a/src/test/java/com/naribackend/token/TokenIntegrationDocsTest.java
+++ b/src/test/java/com/naribackend/token/TokenIntegrationDocsTest.java
@@ -6,6 +6,7 @@ import com.naribackend.support.ApiResponseDocs;
 import com.naribackend.support.TestUser;
 import com.naribackend.support.TestUserFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
+@Disabled("현재 Realtime 임시 토큰 생성 API는 사용하지 않음")
 public class TokenIntegrationDocsTest {
 
     @Autowired

--- a/src/test/java/com/naribackend/token/TokenIntegrationTest.java
+++ b/src/test/java/com/naribackend/token/TokenIntegrationTest.java
@@ -43,6 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
+@Disabled("현재 Realtime 임시 토큰 생성 API는 사용하지 않음")
 public class TokenIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/naribackend/token/TokenIntegrationTest.java
+++ b/src/test/java/com/naribackend/token/TokenIntegrationTest.java
@@ -10,6 +10,7 @@ import com.naribackend.support.TestUser;
 import com.naribackend.support.TestUserFactory;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -195,7 +196,9 @@ public class TokenIntegrationTest {
         }
     }
 
+
     @RepeatedTest(5)
+    @Disabled("현재 Realtime 임시 토큰 생성 API는 사용하지 않음")
     @DisplayName("Realtime 임시 토큰 생성 API 성공 - 동시 요청 처리")
     void create_realtime_token_concurrent_requests_success() throws Exception {
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- 연관된 이슈 번호를 작성해주세요.

Close #36 

## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. #36에 제시된 사항들을 모두 반영 하였습니다.
2. Talk session을 생성하는데 필요한 도메인을 Credit History에서 Talk로 변경하였습니다. https://github.com/Nari-Natural-AI-for-Reflecting-Insight/NARI-Backend/issues/36
3. 추가적으로 이용한 가능한 talk 정보 조회 기능에 대해서 통합 테스트도 추가 하였습니다. 


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 