### PR TITLE
[feat] 다이어리 목록조회 mock api 기능 추가 

### DIFF
--- a/src/main/java/com/naribackend/api/v1/diary/DiaryController.java
+++ b/src/main/java/com/naribackend/api/v1/diary/DiaryController.java
@@ -1,0 +1,42 @@
+package com.naribackend.api.v1.diary;
+
+import com.naribackend.api.v1.diary.response.GetDiariesResponse;
+import com.naribackend.core.auth.CurrentUser;
+import com.naribackend.core.auth.LoginUser;
+import com.naribackend.core.diary.DiaryInfo;
+import com.naribackend.core.diary.DiaryService;
+import com.naribackend.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @Operation(
+            summary = "다이어리 목록 조회",
+            description = "특정 연도와 월에 작성된 다이어리를 목록 조회합니다."
+    )
+    @GetMapping("/diaries")
+    public ApiResponse<?> getDiaries(
+            @Parameter(hidden = true) @CurrentUser LoginUser loginUser,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        List<DiaryInfo> diaryInfos = diaryService.getDiaryInfos(loginUser, year, month);
+
+        return ApiResponse.success(
+                GetDiariesResponse.from(diaryInfos)
+        );
+    }
+}

--- a/src/main/java/com/naribackend/api/v1/diary/response/GetDiariesResponse.java
+++ b/src/main/java/com/naribackend/api/v1/diary/response/GetDiariesResponse.java
@@ -1,0 +1,13 @@
+package com.naribackend.api.v1.diary.response;
+
+import com.naribackend.core.diary.DiaryInfo;
+
+import java.util.List;
+
+public record GetDiariesResponse (
+        List<DiaryInfo> diaries
+){
+    public static GetDiariesResponse from(List<DiaryInfo> diaryInfos) {
+        return new GetDiariesResponse(diaryInfos);
+    }
+}

--- a/src/main/java/com/naribackend/core/diary/DiaryInfo.java
+++ b/src/main/java/com/naribackend/core/diary/DiaryInfo.java
@@ -1,0 +1,15 @@
+package com.naribackend.core.diary;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record DiaryInfo (
+        Long diaryId,
+        List<QnAInfo> qnaList,
+        LocalDateTime diaryDate,
+        DiaryStatus status
+){
+}

--- a/src/main/java/com/naribackend/core/diary/DiaryService.java
+++ b/src/main/java/com/naribackend/core/diary/DiaryService.java
@@ -1,0 +1,95 @@
+package com.naribackend.core.diary;
+
+import com.naribackend.core.auth.LoginUser;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class DiaryService {
+
+    public List<DiaryInfo> getDiaryInfos(final LoginUser loginUser, final int year, final int month) {
+        LocalDateTime diaryDate = LocalDateTime.of(year, month, 1, 0, 0);
+
+        List<DiaryInfo> diaryInfos = new ArrayList<>();
+        for(int day = 1; day <= diaryDate.toLocalDate().lengthOfMonth(); day++) {
+            diaryDate = diaryDate.withDayOfMonth(day);
+            if (day % 3 == 0) {
+                diaryInfos.add(compltedDiaryInfo(day, diaryDate));
+            } else if (day % 3 == 1) {
+                diaryInfos.add(inProgressDiaryInfo(day, diaryDate));
+            } else {
+                diaryInfos.add(notStartedDiaryInfo(diaryDate));
+            }
+        }
+
+        return diaryInfos;
+    }
+
+    public DiaryInfo compltedDiaryInfo(final int day,final LocalDateTime diaryDate) {
+
+        Long diaryId = (long) day + 50L; // day와 구분하기 위해 50을 더함
+        Long qnaId = (long) day + 100L; // day와 구분하기 위해 100을 더함
+
+        return DiaryInfo.builder()
+                .diaryId(diaryId) // day와 구분하기 위해 50을 더함
+                .qnaList(List.of(
+                        QnAInfo.builder()
+                                .qnaId(qnaId + 1L)
+                                .question("오늘은 어땠나요?")
+                                .answer("오늘은 정말 행복한 하루였어요! 아침부터 날씨가 좋아서 기분이 상쾌했고, 출근길에 들은 음악도 너무 좋아서 하루를 기분 좋게 시작할 수 있었어요. 일도 생각보다 잘 풀려서 뿌듯했고, 점심에는 오랜만에 동료들과 웃으면서 식사도 했거든요. 소소한 일상이지만 감사함을 느낄 수 있었던 하루였어요.")
+                                .build(),
+                        QnAInfo.builder()
+                                .qnaId(qnaId + 2L)
+                                .question("오늘의 기분은 어땠나요?")
+                                .answer("오늘은 기분이 꽤 좋았어요! 별다른 특별한 일이 있었던 건 아니지만, 작은 일에도 웃을 수 있었던 하루였거든요. 햇살이 따뜻하게 느껴져서 괜히 마음이 편안해졌고, 사람들과 나눈 대화도 즐거웠어요. 이런 평범한 날들이 모여서 결국 좋은 인생이 되는 거겠죠?")
+                                .build(),
+                        QnAInfo.builder()
+                                .qnaId(qnaId + 3L)
+                                .question("오늘의 목표는 무엇이었나요?")
+                                .answer("오늘은 운동을 열심히 하기로 마음먹었어요! 최근에 체력이 떨어진 것 같아서 다시 운동 루틴을 잡아보려 했죠. 그래서 아침에 일찍 일어나 스트레칭부터 가볍게 시작했고, 저녁엔 헬스장에 가서 땀을 쫙 빼고 왔어요. 운동은 늘 시작이 어렵지만 하고 나면 개운하고 뿌듯해서 계속 이어가고 싶다는 생각이 들었어요.")
+                                .build()
+                ))
+                .diaryDate(diaryDate)
+                .status(DiaryStatus.COMPLETED)
+                .build();
+    }
+
+    public DiaryInfo inProgressDiaryInfo(final int day, final LocalDateTime diaryDate) {
+
+        Long diaryId = (long) day + 50L; // day와 구분하기 위해 50을 더함
+        Long qnaId = (long) day + 100L; // day와 구분하기 위해 100을 더함
+
+        return DiaryInfo.builder()
+                .diaryId(diaryId)
+                .qnaList(List.of(
+                        QnAInfo.builder()
+                                .qnaId(qnaId + 1L)
+                                .question("오늘은 어땠나요?")
+                                .answer("오늘은 정말 행복한 하루였어요! 아침부터")
+                                .build(),
+                        QnAInfo.builder()
+                                .qnaId(qnaId + 2L)
+                                .question("오늘의 기분은 어땠나요?")
+                                .answer("")
+                                .build(),
+                        QnAInfo.builder()
+                                .qnaId(qnaId + 3L)
+                                .question("오늘의 목표는 무엇이었나요?")
+                                .answer("")
+                                .build()
+                ))
+                .diaryDate(diaryDate)
+                .status(DiaryStatus.IN_PROGRESS)
+                .build();
+    }
+
+    public DiaryInfo notStartedDiaryInfo(final LocalDateTime diaryDate) {
+        return DiaryInfo.builder()
+                .diaryDate(diaryDate)
+                .status(DiaryStatus.NOT_STARTED)
+                .build();
+    }
+}

--- a/src/main/java/com/naribackend/core/diary/DiaryStatus.java
+++ b/src/main/java/com/naribackend/core/diary/DiaryStatus.java
@@ -1,0 +1,7 @@
+package com.naribackend.core.diary;
+
+public enum DiaryStatus {
+    NOT_STARTED,
+    COMPLETED,
+    IN_PROGRESS
+}

--- a/src/main/java/com/naribackend/core/diary/QnAInfo.java
+++ b/src/main/java/com/naribackend/core/diary/QnAInfo.java
@@ -1,0 +1,11 @@
+package com.naribackend.core.diary;
+
+import lombok.Builder;
+
+@Builder
+public record QnAInfo (
+    Long qnaId,
+    String question,
+    String answer
+){
+}


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- Close #49 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 다이어리 목록 조회에 대한 mock api를 추가 하였어요 


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 
