### PR TITLE
[feat, test] 대화 IN_PROGRESS, CANCELED 상태 변경

### DIFF
--- a/src/main/java/com/naribackend/api/v1/talk/TalkController.java
+++ b/src/main/java/com/naribackend/api/v1/talk/TalkController.java
@@ -41,6 +41,20 @@ public class TalkController {
     }
 
     @Operation(
+            summary = "Talk 취소",
+            description = "Talk을 취소합니다. 이 API는 진행중인 Talk를 취소할 때, 호출되어야 합니다."
+    )
+    @PostMapping("/{talkId}/cancel")
+    public ApiResponse<?> cancelTalk(
+            @Parameter(hidden = true) @CurrentUser final LoginUser loginUser,
+            @PathVariable final Long talkId
+    ) {
+        talkService.cancelTalk(loginUser, talkId);
+
+        return ApiResponse.success();
+    }
+
+    @Operation(
             summary = "Talk Session 생성",
             description = "실시간 대화와 관련된 정보를 기록하는 Talk Session을 생성합니다. 이 API는 외부 대화 Session 이 시작될 때 호출되어야 합니다."
     )

--- a/src/main/java/com/naribackend/core/talk/Talk.java
+++ b/src/main/java/com/naribackend/core/talk/Talk.java
@@ -46,7 +46,53 @@ public class Talk {
         this.completedAt = completedAt;
     }
 
+    public void cancel() {
+
+        if(this.isCompleted()) {
+            throw new CoreException(ErrorType.TALK_ALREADY_COMPLETED);
+        }
+
+        if(this.isCanceled()) {
+            throw new CoreException(ErrorType.TALK_ALREADY_CANCELED);
+        }
+
+        if(this.isCreated()) {
+            throw new CoreException(ErrorType.TALK_CANNOT_BE_CANCELED);
+        }
+
+        this.status = TalkStatus.CANCELED;
+    }
+
+    public void start() {
+
+        if(this.isCompleted()) {
+            throw new CoreException(ErrorType.TALK_ALREADY_COMPLETED);
+        }
+
+        if(this.isInProgress()) {
+            throw new CoreException(ErrorType.TALK_ALREADY_IN_PROGRESS);
+        }
+
+        this.status = TalkStatus.IN_PROGRESS;
+    }
+
+    public boolean isCanceled() {
+        return this.status == TalkStatus.CANCELED;
+    }
+
+    public boolean isExpired(final LocalDateTime currentDateTime) {
+        return this.expiredAt.isBefore(currentDateTime);
+    }
+
     public boolean isCompleted() {
         return this.status == TalkStatus.COMPLETED;
+    }
+
+    public boolean isCreated() {
+        return this.status == TalkStatus.CREATED;
+    }
+
+    public boolean isInProgress() {
+        return this.status == TalkStatus.IN_PROGRESS;
     }
 }

--- a/src/main/java/com/naribackend/core/talk/TalkService.java
+++ b/src/main/java/com/naribackend/core/talk/TalkService.java
@@ -51,4 +51,18 @@ public class TalkService {
         talk.complete(completedAt);
         talkRepository.save(talk);
     }
+
+    @Transactional
+    public void cancelTalk(final LoginUser loginUser, final Long talkId) {
+
+        Talk talk = talkRepository.findById(talkId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_TALK));
+
+        if (!talk.isUserCreated(loginUser)) {
+            throw new CoreException(ErrorType.INVALID_USER_REQUEST);
+        }
+
+        talk.cancel();
+        talkRepository.save(talk);
+    }
 }

--- a/src/main/java/com/naribackend/core/talk/TalkService.java
+++ b/src/main/java/com/naribackend/core/talk/TalkService.java
@@ -46,6 +46,8 @@ public class TalkService {
         }
 
         LocalDateTime completedAt = dateTimeProvider.getCurrentDateTime();
+
+        // Talk Session의 상태를 완료로 변경
         talkSessionRepository.modifyNotCanceledStatusToCompletedStatusBy(loginUser, talk, completedAt);
 
         talk.complete(completedAt);
@@ -61,6 +63,9 @@ public class TalkService {
         if (!talk.isUserCreated(loginUser)) {
             throw new CoreException(ErrorType.INVALID_USER_REQUEST);
         }
+
+        // Talk Session의 상태를 취소로 변경
+        talkSessionRepository.modifyInProgressStatusToCanceledStatusBy(loginUser, talk);
 
         talk.cancel();
         talkRepository.save(talk);

--- a/src/main/java/com/naribackend/core/talk/TalkSession.java
+++ b/src/main/java/com/naribackend/core/talk/TalkSession.java
@@ -29,6 +29,14 @@ public class TalkSession {
                 .build();
     }
 
+    public static TalkSession startBy(final Talk parentTalk) {
+        return TalkSession.builder()
+                .parentTalkId(parentTalk.getId())
+                .createdUserId(parentTalk.getCreatedUserId())
+                .status(TalkSessionStatus.IN_PROGRESS)
+                .build();
+    }
+
     public void complete(final LocalDateTime currentTime) {
         this.status = TalkSessionStatus.COMPLETED;
         this.completedAt = currentTime;

--- a/src/main/java/com/naribackend/core/talk/TalkSessionRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkSessionRepository.java
@@ -16,4 +16,6 @@ public interface TalkSessionRepository {
     Optional<TalkSession> findById(Long talkSessionId);
 
     int modifyNotCanceledStatusToCompletedStatusBy(LoginUser createdUser, Talk parentTalk, LocalDateTime completedAt);
+
+    void modifyInProgressStatusToCanceledStatusBy(LoginUser loginUser, Talk talk);
 }

--- a/src/main/java/com/naribackend/core/talk/TalkSessionService.java
+++ b/src/main/java/com/naribackend/core/talk/TalkSessionService.java
@@ -63,17 +63,14 @@ public class TalkSessionService {
             throw new CoreException(ErrorType.COMPLETED_TALK_SESSION_EXISTS);
         }
 
-        // Talk 완료 처리, 최대 세션 수에 도달한 경우
-        if (childTalkSession >= talkPolicyProperties.getMaxSessionCountPerPay() - 1) {
-            parentTalk.complete(dateTimeProvider.getCurrentDateTime());
-            talkRepository.save(parentTalk);
-        }
+        // Talk 상태 IN_PROGRESS로 변경
+        parentTalk.start();
+        talkRepository.save(parentTalk);
 
-        TalkSession savedTalkSession = talkSessionRepository.save(
-                TalkSession.from(parentTalk)
+        // TalkSession 생성 및 상태 IN_PROGRESS로 설정
+        return talkSessionRepository.save(
+                TalkSession.startBy(parentTalk)
         );
-
-        return savedTalkSession;
     }
 
 

--- a/src/main/java/com/naribackend/storage/BaseEntity.java
+++ b/src/main/java/com/naribackend/storage/BaseEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder(toBuilder = true)
 public abstract class BaseEntity {
 
     @CreationTimestamp

--- a/src/main/java/com/naribackend/storage/talk/TalkEntity.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkEntity.java
@@ -5,13 +5,13 @@ import com.naribackend.core.talk.TalkStatus;
 import com.naribackend.storage.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @Table(name = "talk")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
@@ -45,6 +45,8 @@ public class TalkEntity extends BaseEntity {
                 .status(talk.getStatus())
                 .expiredAt(talk.getExpiredAt())
                 .completedAt(talk.getCompletedAt())
+                .createdAt(talk.getCreatedAt())
+                .modifiedAt(talk.getModifiedAt())
                 .build();
     }
 

--- a/src/main/java/com/naribackend/storage/talk/TalkSessionEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkSessionEntityRepository.java
@@ -59,4 +59,12 @@ public class TalkSessionEntityRepository implements TalkSessionRepository {
                 completedAt
         );
     }
+
+    @Override
+    public void modifyInProgressStatusToCanceledStatusBy(LoginUser loginUser, Talk talk) {
+        talkSessionJpaRepository.modifyInProgressStatusToCanceledStatusBy(
+                loginUser.getId(),
+                talk.getId()
+        );
+    }
 }

--- a/src/main/java/com/naribackend/storage/talk/TalkSessionJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkSessionJpaRepository.java
@@ -28,4 +28,14 @@ public interface TalkSessionJpaRepository extends JpaRepository<TalkSessionEntit
             Long talkId,
             LocalDateTime completedAt
     );
+
+    @Modifying
+    @Query("""
+        UPDATE TalkSessionEntity t
+        SET t.status = 'CANCELED'
+            WHERE t.status = 'IN_PROGRESS'
+                AND t.createdUserId = :createdUserId
+                AND t.parentTalkId = :talkId
+    """)
+    void modifyInProgressStatusToCanceledStatusBy(Long createdUserId, Long talkId);
 }

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -40,6 +40,12 @@ public enum ErrorType {
     TALK_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 대화 세션을 찾을 수 없습니다.", LogLevel.INFO),
     INVALID_USER_REQUEST(HttpStatus.FORBIDDEN, ErrorCode.E403, "해당 요청은 권한이 없습니다.", LogLevel.INFO),
     TALK_ALREADY_CANCELED(HttpStatus.CONFLICT, ErrorCode.E409, "해당 대화는 이미 취소되었습니다.", LogLevel.DEBUG),
+    TALK_SESSION_CANNOT_BE_STARTED(
+            HttpStatus.CONFLICT,
+            ErrorCode.E409,
+            "해당 대화 세션은 시작할 수 없습니다.",
+            LogLevel.DEBUG
+    ),
     TALK_ALREADY_IN_PROGRESS(
             HttpStatus.CONFLICT,
             ErrorCode.E409,

--- a/src/main/java/com/naribackend/support/error/ErrorType.java
+++ b/src/main/java/com/naribackend/support/error/ErrorType.java
@@ -39,6 +39,19 @@ public enum ErrorType {
     TALK_SESSION_COMPLETED(HttpStatus.CONFLICT, ErrorCode.E409, "이미 완료된 대화 세션입니다.", LogLevel.INFO),
     TALK_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 대화 세션을 찾을 수 없습니다.", LogLevel.INFO),
     INVALID_USER_REQUEST(HttpStatus.FORBIDDEN, ErrorCode.E403, "해당 요청은 권한이 없습니다.", LogLevel.INFO),
+    TALK_ALREADY_CANCELED(HttpStatus.CONFLICT, ErrorCode.E409, "해당 대화는 이미 취소되었습니다.", LogLevel.DEBUG),
+    TALK_ALREADY_IN_PROGRESS(
+            HttpStatus.CONFLICT,
+            ErrorCode.E409,
+            "해당 대화는 이미 진행 중입니다.",
+            LogLevel.DEBUG
+    ),
+    TALK_CANNOT_BE_CANCELED(
+            HttpStatus.CONFLICT,
+            ErrorCode.E409,
+            "해당 대화는 취소할 수 없습니다.",
+            LogLevel.DEBUG
+    ),
     TALK_ALREADY_COMPLETED(
             HttpStatus.CONFLICT,
             ErrorCode.E409,

--- a/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
+++ b/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
@@ -3,7 +3,6 @@ package com.naribackend.talk;
 import com.jayway.jsonpath.JsonPath;
 import com.naribackend.core.DateTimeProvider;
 import com.naribackend.core.auth.LoginUser;
-import com.naribackend.core.idempotency.IdempotencyKey;
 import com.naribackend.core.talk.*;
 import com.naribackend.support.TestUser;
 import com.naribackend.support.TestUserFactory;
@@ -126,15 +125,14 @@ public class TalkIntegrationTest {
         Talk expectedParentTalk = talkFactory.createTalk(
                 testUser.id()
         );
+        expectedParentTalk.start();
+        expectedParentTalk.complete(LocalDateTime.now());
+        expectedParentTalk = talkRepository.save(expectedParentTalk);
 
-        // Talk가 완료되도록 Talk Session을 생성
-        for(int i=0; i < talkPolicyProperties.getMaxSessionCountPerPay(); i++) {
-            talkSessionService.createTalkSession(
-                    expectedParentTalk.getId(),
-                    testUser.toLoginUser(),
-                    IdempotencyKey.from(IDEMPOTENCY_KEY + i)
-            );
-        }
+        talkService.completeTalk(
+                testUser.toLoginUser(),
+                expectedParentTalk.getId()
+        );
 
         // when
         var topActiveTalkInfo = talkService.getTopActiveTalkInfo(testUser.toLoginUser());


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- Close #51 

## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 세션 생성할 경우 talk, talk session 의 상태를 IN_PROGRESS로 변경 기능 추가
2. talk를 취소하여 talk, talk session의 상태를 CANCELED로 변경 기능 추가 
3. 관련 추가 기능 테스트 추가 


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 