### PR TITLE
[feat, test] 진행중인 대화 최우선 조회 기능 추가 

### DIFF
--- a/src/main/java/com/naribackend/api/v1/talk/TalkController.java
+++ b/src/main/java/com/naribackend/api/v1/talk/TalkController.java
@@ -93,8 +93,8 @@ public class TalkController {
     }
 
     @Operation(
-            summary = "이용 가능한 Talk 중 하나의 Talk에 대해 상세 정보 조회",
-            description = "사용자가 이용 가능한 Talk를 하나에 대해 조회합니다. 이 API는 사용자가 Talk를 시작하기 전에 호출되어야 합니다."
+            summary = "우선적으로 사용되어야 하는 Talk 정보를 조회",
+            description = "우선적으로 사용되어야 하는 Talk 정보를 조회합니다. 이 API는 사용자가 Talk를 시작하기 전에 호출되어야 합니다."
     )
     @GetMapping("/top-active")
     public ApiResponse<?> getTopActiveTalkInfo(

--- a/src/main/java/com/naribackend/core/talk/TalkRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkRepository.java
@@ -22,5 +22,15 @@ public interface TalkRepository {
 
     Optional<Talk> findById(Long talkId);
 
+    /**
+     * 현재 진행 중인 Talk를 조회합니다.
+     * 조건은 다음과 같습니다.
+     * 1. Talk가 IN_PROGRESS 상태여야 함
+     * 2. Talk의 참여자가 로그인한 사용자여야 함
+     * 3. 만료일이 가장 빠른 Talk를 반환합니다.
+     *
+     * @param loginUser 로그인한 사용자 정보
+     * @return 현재 진행 중인 Talk 정보
+     */
     Optional<Talk> findInProgressTalkBy(LoginUser loginUser);
 }

--- a/src/main/java/com/naribackend/core/talk/TalkRepository.java
+++ b/src/main/java/com/naribackend/core/talk/TalkRepository.java
@@ -15,11 +15,12 @@ public interface TalkRepository {
     * 2. Talk의 참여자가 로그인한 사용자여야 함
     * 3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
     * 4. Talk의 갯수은 1개여야 함
-    * 5. max-session-count-per-pay 값이 Talk의 sessionCount보다 작아야함
+    * 5. Talk의 sessionCount이 max-session-count-per-pay 값보다 작아야 함
     *
     * */
     Optional<Talk> findNotCompletedTopTalkById(LoginUser loginUser, long maxSessionCountPerPay);
 
     Optional<Talk> findById(Long talkId);
 
+    Optional<Talk> findInProgressTalkBy(LoginUser loginUser);
 }

--- a/src/main/java/com/naribackend/core/talk/TalkService.java
+++ b/src/main/java/com/naribackend/core/talk/TalkService.java
@@ -22,11 +22,28 @@ public class TalkService {
 
     private final DateTimeProvider dateTimeProvider;
 
+    /**.
+     * 우선적으로 사용되어야 하는 Talk 정보를 조회합니다.
+     *
+     * 조건은 다음과 같습니다.
+     * 1. 현재 진행 중인 Talk가 있다면 해당 Talk 정보를 반환합니다.
+     * 2. 현재 진행 중인 Talk가 없다면, 사용자가 결제한 Talk 중에서 아직 완료되지 않은 Talk 정보를 반환합니다.
+     *  세부 조건은 다음과 같습니다.
+     *     1. Talk가 COMPLETED 상태가 아니여야 함
+     *     2. Talk의 참여자가 로그인한 사용자여야 함
+     *     3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
+     *     4. Talk의 sessionCount이 max-session-count-per-pay 값보다 작아야 함
+     * 3. 만약 위의 두 조건에 해당하는 Talk가 없다면, TalkTopActiveInfo.empty()를 반환합니다.
+     *
+     * @param loginUser
+     * @return TalkTopActiveInfo 우선적으로 사용되어야 하는 Talk 정보
+     */
     public TalkTopActiveInfo getTopActiveTalkInfo(final LoginUser loginUser) {
 
         int maxSessionCountPerPay = talkPolicyProperties.getMaxSessionCountPerPay();
 
-        return talkRepository.findNotCompletedTopTalkById(loginUser, maxSessionCountPerPay)
+        return talkRepository.findInProgressTalkBy(loginUser)
+                .or(() -> talkRepository.findNotCompletedTopTalkById(loginUser, maxSessionCountPerPay))
                 .map(talk -> TalkInfo.from(talk, talkSessionRepository.countBy(talk)))
                 .map(talkInfo -> TalkTopActiveInfo.from(talkInfo, maxSessionCountPerPay))
                 .orElseGet(TalkTopActiveInfo::empty);

--- a/src/main/java/com/naribackend/core/talk/TalkService.java
+++ b/src/main/java/com/naribackend/core/talk/TalkService.java
@@ -22,11 +22,11 @@ public class TalkService {
 
     private final DateTimeProvider dateTimeProvider;
 
-    /**.
+    /**
      * 우선적으로 사용되어야 하는 Talk 정보를 조회합니다.
      *
      * 조건은 다음과 같습니다.
-     * 1. 현재 진행 중인 Talk가 있다면 해당 Talk 정보를 반환합니다.
+     * 1. 현재 진행 중인 Talk가 있다면, 만료일을 오름차순으로 Talk 정보를 반환합니다.
      * 2. 현재 진행 중인 Talk가 없다면, 사용자가 결제한 Talk 중에서 아직 완료되지 않은 Talk 정보를 반환합니다.
      *  세부 조건은 다음과 같습니다.
      *     1. Talk가 COMPLETED 상태가 아니여야 함
@@ -35,7 +35,7 @@ public class TalkService {
      *     4. Talk의 sessionCount이 max-session-count-per-pay 값보다 작아야 함
      * 3. 만약 위의 두 조건에 해당하는 Talk가 없다면, TalkTopActiveInfo.empty()를 반환합니다.
      *
-     * @param loginUser
+     * @param loginUser 로그인한 사용자 정보
      * @return TalkTopActiveInfo 우선적으로 사용되어야 하는 Talk 정보
      */
     public TalkTopActiveInfo getTopActiveTalkInfo(final LoginUser loginUser) {

--- a/src/main/java/com/naribackend/core/talk/TalkTopActiveInfo.java
+++ b/src/main/java/com/naribackend/core/talk/TalkTopActiveInfo.java
@@ -3,6 +3,8 @@ package com.naribackend.core.talk;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Objects;
+
 @Getter
 @Builder
 public class TalkTopActiveInfo {
@@ -14,8 +16,15 @@ public class TalkTopActiveInfo {
     private int maxSessionCountPerPay;
 
     public static TalkTopActiveInfo from(TalkInfo topActiveTalkInfo, int maxSessionCountPerPay) {
+
+        boolean existsActiveTalk = Objects.nonNull(topActiveTalkInfo);
+
+        if (!existsActiveTalk) {
+            return empty();
+        }
+
         return TalkTopActiveInfo.builder()
-                .existsActiveTalk(topActiveTalkInfo != null)
+                .existsActiveTalk(true)
                 .topActiveTalkInfo(topActiveTalkInfo)
                 .maxSessionCountPerPay(maxSessionCountPerPay)
                 .build();

--- a/src/main/java/com/naribackend/storage/talk/TalkEntityRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkEntityRepository.java
@@ -35,8 +35,16 @@ public class TalkEntityRepository implements TalkRepository {
     }
 
     @Override
-    public Optional<Talk> findById(Long talkId) {
+    public Optional<Talk> findById(final Long talkId) {
         return talkJpaRepository.findById(talkId)
                 .map(TalkEntity::toTalk);
+    }
+
+    @Override
+    public Optional<Talk> findInProgressTalkBy(final LoginUser loginUser) {
+        return talkJpaRepository.findInProgressTalkBy(
+                loginUser.getId(),
+                Pageable.ofSize(1)
+        ).stream().findFirst().map(TalkEntity::toTalk);
     }
 }

--- a/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
@@ -39,6 +39,17 @@ public interface TalkJpaRepository extends JpaRepository<TalkEntity, Long> {
             Pageable pageable
     );
 
+    /**
+     * 현재 진행 중인 Talk를 조회합니다.
+     * 조건은 다음과 같습니다.
+     * 1. Talk가 IN_PROGRESS 상태여야 함
+     * 2. Talk의 참여자가 createdUserId여야 함
+     * 3. 만료일이 가장 빠른 Talk를 반환합니다.
+     *
+     * @param createdUserId 참여자 ID
+     * @param pageable 페이징 정보
+     * @return 현재 진행 중인 Talk 엔티티
+     */
     @Query("""
         select talkEntity
         from TalkEntity talkEntity

--- a/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
+++ b/src/main/java/com/naribackend/storage/talk/TalkJpaRepository.java
@@ -13,9 +13,9 @@ public interface TalkJpaRepository extends JpaRepository<TalkEntity, Long> {
      * 1. Talk가 COMPLETED 상태가 아니여야 함
      * 2. Talk의 참여자가 userId여야 함
      * 3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
-     * 4. max-session-count-per-pay 값이 Talk의 sessionCount보다 작아야함
+     * 4. Talk의 sessionCount이 max-session-count-per-pay 값보다 작아야 함
      *
-     * @param userId                참여자 ID
+     * @param userId 참여자 ID
      * @param maxSessionCountPerPay 최대 세션 수
      * @return 조건을 만족하는 Talk 엔티티
      */
@@ -38,4 +38,13 @@ public interface TalkJpaRepository extends JpaRepository<TalkEntity, Long> {
             @Param("maxSessionCountPerPay") long maxSessionCountPerPay,
             Pageable pageable
     );
+
+    @Query("""
+        select talkEntity
+        from TalkEntity talkEntity
+        where talkEntity.status = com.naribackend.core.talk.TalkStatus.IN_PROGRESS
+        and talkEntity.createdUserId = :createdUserId
+        order by talkEntity.expiredAt asc
+    """)
+    Page<TalkEntity> findInProgressTalkBy(long createdUserId, Pageable pageable);
 }

--- a/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
+++ b/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -55,7 +56,7 @@ public class TalkIntegrationTest {
     @Autowired
     private TalkPolicyProperties talkPolicyProperties;
 
-    @Autowired
+    @MockitoSpyBean
     private TalkRepository talkRepository;
 
     @Autowired
@@ -67,8 +68,6 @@ public class TalkIntegrationTest {
     private static final String TOP_ACTIVE_TALK_API_PATH = "/api/v1/talk/top-active";
 
     private static final String TALK_COMPLETED_API_PATH = "/api/v1/talk/{talkId}/complete";
-
-    private static final String IDEMPOTENCY_KEY = "top-active-talk";
 
     @MockitoSpyBean
     private DateTimeProvider dateTimeProvider;
@@ -159,8 +158,13 @@ public class TalkIntegrationTest {
         assertThat(topActiveTalkInfo.isExistsActiveTalk()).isFalse();
     }
 
+    /**
+     * top active talk 조회 성공 - 조회 조건 검사, IN_PROGRESS Talk가 없는 경우
+     * 이 테스트는 Talk의 상태가 CREATED, CANCELED, COMPLETED인 경우에 대해 테스트
+     * IN_PROGRESS는 다른 조건을 무시하고 최우선적으로 조회되기 때문에,해당 테스트에서는 IN_PROGRESS Talk가 없는 후 순위 상태에 대해서 테스트 합니다.
+     */
     @RepeatedTest(5)
-    @DisplayName("top active talk 조회 성공 - 조회 조건 검사")
+    @DisplayName("top active talk 조회 성공 - 조회 조건 검사, IN_PROGRESS Talk가 없는 경우")
     void get_top_active_talk_service_success_check_sort_condition() {
         // given
         int userCount = 10;
@@ -168,7 +172,7 @@ public class TalkIntegrationTest {
         int maxSessionCountPerPay = talkPolicyProperties.getMaxSessionCountPerPay();
         var talkStatus = List.of(
                 TalkStatus.CREATED,
-                TalkStatus.IN_PROGRESS,
+                TalkStatus.CANCELED,
                 TalkStatus.COMPLETED
         );
 
@@ -201,8 +205,8 @@ public class TalkIntegrationTest {
           1. Talk가 COMPLETED 상태가 아니여야 함
           2. Talk의 참여자가 expectedUserId 함
           3. 생성일로 오름차순, Talk의 sessionCount로 내림차순 정렬되어야 함
-          4. max-session-count-per-pay 값이 Talk의 sessionCount보다 작아야함
-          5. Talk의 만료일이 현재 시간보다 이후여야 함
+          4. Talk의 sessionCount이 max-session-count-per-pay 값보다 작아야 함
+          5. Talk의 만료 시간이 현재 시간보다 이후여야 함
          */
         var expectedTopActiveTalkInfos = talkInfos.stream()
                 .filter(talkInfo -> talkInfo.getCreatedSessionCount() < maxSessionCountPerPay)
@@ -222,6 +226,36 @@ public class TalkIntegrationTest {
         // then
         assertThat(topActiveTalkInfo.isExistsActiveTalk()).isTrue();
         assertThat(topActiveTalkInfo.getTopActiveTalkInfo().getTalkId()).isEqualTo(expectedTopActiveTalkInfo.getTalkId());
+    }
+
+    @Test
+    @DisplayName("top active talk 조회 성공 - IN_PROGRESS Talk가 있는 경우, IN_PROGRESS Talk가 우선적으로 조회되어야 함")
+    void get_top_active_talk_service_success_in_progress_talk() {
+        // given
+        TestUser testUser = testUserFactory.createTestUser();
+        Talk expectedParentTalk = talkFactory.createTalk(
+                testUser.id()
+        );
+
+        // IN_PROGRESS Talk 변경
+        expectedParentTalk.start();
+        expectedParentTalk = talkRepository.save(expectedParentTalk);
+
+        // 다른 Talk 생성
+        Talk otherTalk = talkFactory.createTalk(
+                testUser.id()
+        );
+
+        // IN_PROGRESS가 없는 경우, 실행되는 메서드
+        when(talkRepository.findNotCompletedTopTalkById(testUser.toLoginUser(), talkPolicyProperties.getMaxSessionCountPerPay()))
+                .thenReturn(Optional.of(otherTalk));
+
+        // when
+        var topActiveTalkInfo = talkService.getTopActiveTalkInfo(testUser.toLoginUser());
+
+        // then
+        assertThat(topActiveTalkInfo.isExistsActiveTalk()).isTrue();
+        assertThat(topActiveTalkInfo.getTopActiveTalkInfo().getTalkId()).isEqualTo(expectedParentTalk.getId());
     }
 
     @Test

--- a/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
+++ b/src/test/java/com/naribackend/talk/TalkIntegrationTest.java
@@ -51,9 +51,6 @@ public class TalkIntegrationTest {
     private TalkService talkService;
 
     @Autowired
-    private TalkSessionService talkSessionService;
-
-    @Autowired
     private TalkPolicyProperties talkPolicyProperties;
 
     @MockitoSpyBean
@@ -161,7 +158,7 @@ public class TalkIntegrationTest {
     /**
      * top active talk 조회 성공 - 조회 조건 검사, IN_PROGRESS Talk가 없는 경우
      * 이 테스트는 Talk의 상태가 CREATED, CANCELED, COMPLETED인 경우에 대해 테스트
-     * IN_PROGRESS는 다른 조건을 무시하고 최우선적으로 조회되기 때문에,해당 테스트에서는 IN_PROGRESS Talk가 없는 후 순위 상태에 대해서 테스트 합니다.
+     * IN_PROGRESS는 다른 조건을 무시하고 최우선적으로 조회되기 때문에, 해당 테스트에서는 IN_PROGRESS Talk가 없는 후 순위 상태에 대해서 테스트 합니다.
      */
     @RepeatedTest(5)
     @DisplayName("top active talk 조회 성공 - 조회 조건 검사, IN_PROGRESS Talk가 없는 경우")


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈
<!-- 
  예시: 
  - closes #123  
  - fixes #456  
-->
- Cloese #53 


## 변경 내용
<!-- 
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->
1. 최우선 대화 조회시, 진행중인 대화를 가장 먼저 조회되도록 기능 추가(#53)
2. 기존 테스트에 변경 및 최우선 조회 테스트 추가


## 주의 사항
<!-- 
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등 
-->
- 없음 
